### PR TITLE
Improve the verify step for the petclinic-jpa sample.

### DIFF
--- a/spring-native-samples/petclinic-jpa/verify.sh
+++ b/spring-native-samples/petclinic-jpa/verify.sh
@@ -1,7 +1,23 @@
 #!/usr/bin/env bash
 RESPONSE=`curl -s localhost:8080`
-if [[ $RESPONSE == *"Welcome"* ]]; then
- exit 0
-else
+if [[ $RESPONSE != *"Welcome"* ]]; then
  exit 1
 fi
+
+RESPONSE=`curl -s http://localhost:8080/owners/7`
+if [[ $RESPONSE != *"Jeff Black"* ]]; then
+ exit 2
+fi
+
+RESPONSE=`curl -s http://localhost:8080/vets.html`
+if [[ $RESPONSE != *"James Carter"* ]]; then
+ exit 3
+fi
+
+RESPONSE=`curl -Ls "http://localhost:8080/owners?lastName=Frank"`
+if [[ $RESPONSE != *"George Franklin"* ]]; then
+ exit 4
+fi
+
+exit 0
+


### PR DESCRIPTION
The previous verify.sh just accessed the home page ignoring pretty much all repository methods including those that are very suitable for finding problems with hints and similar.

Now we access a small collection of end points in order to exercise those repository methods.