### PR TITLE
Fix resource backslash issue at source rather than during JSONify

### DIFF
--- a/spring-aot/src/main/java/org/springframework/aot/BootstrapCodeGenerator.java
+++ b/spring-aot/src/main/java/org/springframework/aot/BootstrapCodeGenerator.java
@@ -83,15 +83,16 @@ public class BootstrapCodeGenerator {
 				if (Files.exists(resourceFolder)) {
 					Files.walk(resourceFolder).filter(p -> !p.toFile().isDirectory()).forEach(p -> {
 						String resourcePattern = p.toString().substring(resourceFolderLen);
-						if (!resourcePattern.startsWith("META-INF/native-image")) {
+						String platformNormalisedResourcePattern = resourcePattern.replace("\\", "/");
+						if (!platformNormalisedResourcePattern.startsWith("META-INF/native-image")) {
 
-							if (matchesPatternInCache(resourcePattern))
+							if (matchesPatternInCache(platformNormalisedResourcePattern))
 								return;
 
-							logger.debug("Resource pattern: " + resourcePattern);
+							logger.debug("Resource pattern: " + platformNormalisedResourcePattern);
 							// TODO recognize resource bundles?
 							// TODO escape the patterns (add leading trailing Q and E sequences...)
-							buildContext.describeResources(crd -> crd.add(resourcePattern));
+							buildContext.describeResources(crd -> crd.add(platformNormalisedResourcePattern));
 						}
 					});
 				}

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/resources/ResourcesJsonMarshaller.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/resources/ResourcesJsonMarshaller.java
@@ -42,7 +42,6 @@ public class ResourcesJsonMarshaller {
 			JSONObject jsonObject = converter.toJsonArray(metadata);
 			outputStream.write(jsonObject.toString(2)
 					.replace("\\/","/")
-					.replace("\\\\","/")
 					.getBytes(StandardCharsets.UTF_8));
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
This is an improved version of previously merged PR https://github.com/spring-projects-experimental/spring-native/pull/521 which was merged in https://github.com/spring-projects-experimental/spring-native/commit/cef5c60ad3fb8fe4bfdfc899513615234a3e49e0

The original fix just fixed the Windows backslash paths to forward-slashes during the final JSONify step in `ResourcesJsonMarshaller`. I went back and had a look at where the original issue stems from in `BootstrapCodeGenerator` and fixed it there instead (which was another use of Files.walk()).

Again, tested on Windows but would be good to have a check on a Linux system.

@aclement, I have not touched a pre-existing `String.replace("\\/","/")`  in `ResourcesJsonMarshaller` which appears to be from an earlier version of the code as I'm not sure what this is trying to do - if you have any recollection possibly this could be moved as well?

I did also consider making a change in `ResourcesDescriptor.add()` method but this seemed like a better approach.