### PR TITLE
Add Maven repository for GAs as well

### DIFF
--- a/spring-native-docs/src/main/asciidoc/getting-started-buildpacks.adoc
+++ b/spring-native-docs/src/main/asciidoc/getting-started-buildpacks.adoc
@@ -191,7 +191,6 @@ NOTE: The builder is also customized to use `paketobuildpacks/builder:tiny`, `pa
 
 TIP: Additional `native-image` arguments can be added using the `BP_BOOT_NATIVE_IMAGE_BUILD_ARGUMENTS` environment variable.
 
-ifeval::["{spring-native-repo}" != "release"]
 ===== Maven Repository
 
 Configure your build to include the required repository for the `spring-native` dependency, as follows:
@@ -256,7 +255,6 @@ pluginManagement {
 }
 ----
 ====
-endif::[]
 
 ==== Build the native application
 

--- a/spring-native-docs/src/main/asciidoc/getting-started-native-image.adoc
+++ b/spring-native-docs/src/main/asciidoc/getting-started-native-image.adoc
@@ -162,7 +162,6 @@ To avoid a clash between the two plugins, make sure to specify a classifier like
 ----
 ====
 
-ifeval::["{spring-native-repo}" != "release"]
 ===== Maven Repository
 
 Configure your build to include the required repository for the `spring-native` dependency, as follows:
@@ -195,7 +194,6 @@ The Spring AOT plugin also requires a dedicated plugin repository:
 </pluginRepositories>
 ----
 ====
-endif::[]
 
 ==== Build the native application
 


### PR DESCRIPTION
Given that Spring Native is not released on Maven Central, a repository
still needs to be configured with a GA. This commit removes the smart
check that used to remove those instructions for a GA.