### PR TITLE
Restructure reference guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,9 +4,9 @@
 :graalvm-version: 20.3.0
 :graalvm-dev-version: 20.1.0
 :boot-dev-version: 2.4.3
-:documentation-url: https://repo.spring.io/{repository}/org/springframework/experimental/spring-graalvm-native-docs/{version}/spring-graalvm-native-docs-{version}.zip!
+:documentation-url: docs.spring.io/spring-native/docs/current-SNAPSHOT/reference/htmlsingle
 
-image:https://ci.spring.io/api/v1/teams/spring-native/pipelines/spring-native/badge["Build Status", link="https://ci.spring.io/teams/spring-native/pipelines/spring-native"] image:https://img.shields.io/badge/{version}-documentation-blue.svg["{version} documentation", link="{documentation-url}/reference/index.html"]
+image:https://ci.spring.io/api/v1/teams/spring-native/pipelines/spring-native/badge["Build Status", link="https://ci.spring.io/teams/spring-native/pipelines/spring-native"] image:https://img.shields.io/badge/{version}-documentation-blue.svg["{version} documentation", link="{documentation-url}"]
 
 Spring Native provides an incubating support for compiling Spring applications to native executables using https://www.graalvm.org[GraalVM] 
 https://www.graalvm.org/reference-manual/native-image/[native-image] compiler, in order to provide a native deployment
@@ -36,7 +36,7 @@ Some changes incubated here are moved directly to https://github.com/spring-proj
 
 == Quick start
 
-For detailed information and walkthroughs of applying the techniques to your project, please see the {documentation-url}/reference/index.html[documentation].
+For detailed information and walkthroughs of applying the techniques to your project, please see the {documentation-url}[documentation].
 
 === Artifacts
 
@@ -51,11 +51,11 @@ The latest {version} release supports GraalVM {graalvm-version} and Spring Boot 
 - Go into the samples folder and pick one (e.g. `cd samples/commandlinerunner`)
 - Run `./build.sh` which will run a maven build, then a native image compile, then test the result.
 
-`build.sh` runs the `compile.sh` script and in that compile script you can see the invocation of the `native-image` command. The other samples follow a similar model. For more details on the samples see the {documentation-url}/reference/index.html#samples[samples documentation].
+`build.sh` runs the `compile.sh` script and in that compile script you can see the invocation of the `native-image` command. The other samples follow a similar model. For more details on the samples see the {documentation-url}/index.html#samples[samples documentation].
 
 == Contributing
 
-This project is in the `spring-projects-experimental` org indicating it is not as mature as other Spring projects. Contributions are welcome (maybe read the {documentation-url}/reference/index.html#extension_guide[extension guide] if thinking about extending it to support your project). However, please recognize we aren't at the polishing javadoc stage and whilst pre 1.0 there may be heavy evolution of APIs.
+This project is in the `spring-projects-experimental` org indicating it is not as mature as other Spring projects. Contributions are welcome (maybe read the {documentation-url}/index.html#extension_guide[extension guide] if thinking about extending it to support your project). However, please recognize we aren't at the polishing javadoc stage and whilst pre 1.0 there may be heavy evolution of APIs.
 
 === Baseline
 

--- a/spring-native-docs/pom.xml
+++ b/spring-native-docs/pom.xml
@@ -83,11 +83,25 @@
 								<version>0.5.0</version>
 							</dependency>
 						</dependencies>
+						<configuration>
+							<sourceDirectory>${refdocs.build.directory}</sourceDirectory>
+							<sourceDocumentName>index.adoc</sourceDocumentName>
+							<doctype>book</doctype>
+							<attributes>
+								<spring-native-repo>${spring-native-repo}</spring-native-repo>
+								<version>${project.version}</version>
+								<projectName>${project.name}</projectName>
+								<projectVersion>${project.version}</projectVersion>
+								<allow-uri-read>true</allow-uri-read>
+								<toclevels>4</toclevels>
+								<numbered>true</numbered>
+								<baseDir>${project.basedir}</baseDir>
+							</attributes>
+						</configuration>
 						<executions>
 							<execution>
 								<id>html</id>
 								<phase>generate-resources</phase>
-								<inherited>false</inherited>
 								<goals>
 									<goal>process-asciidoc</goal>
 								</goals>
@@ -108,11 +122,9 @@
 									</attributes>
 								</configuration>
 							</execution>
-
 							<execution>
 								<id>pdf</id>
 								<phase>generate-resources</phase>
-								<inherited>false</inherited>
 								<goals>
 									<goal>process-asciidoc</goal>
 								</goals>
@@ -134,21 +146,6 @@
 								</configuration>
 							</execution>
 						</executions>
-						<configuration>
-							<sourceDirectory>${refdocs.build.directory}</sourceDirectory>
-							<sourceDocumentName>index.adoc</sourceDocumentName>
-							<doctype>book</doctype>
-							<attributes>
-								<spring-native-repo>${spring-native-repo}</spring-native-repo>
-								<version>${project.version}</version>
-								<projectName>${project.name}</projectName>
-								<projectVersion>${project.version}</projectVersion>
-								<allow-uri-read>true</allow-uri-read>
-								<toclevels>4</toclevels>
-								<numbered>true</numbered>
-								<baseDir>${project.basedir}</baseDir>
-							</attributes>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/spring-native-docs/pom.xml
+++ b/spring-native-docs/pom.xml
@@ -92,6 +92,7 @@
 									<goal>process-asciidoc</goal>
 								</goals>
 								<configuration>
+									<outputDirectory>${project.build.directory}/generated-docs/reference/htmlsingle</outputDirectory>
 									<backend>html5</backend>
 									<sourceHighlighter>highlight.js</sourceHighlighter>
 									<attributes>
@@ -118,6 +119,18 @@
 								<configuration>
 									<backend>pdf</backend>
 									<sourceHighlighter>coderay</sourceHighlighter>
+									<sourceDocumentExtensions>
+										<sourceDocumentExtension>pdfadoc</sourceDocumentExtension>
+									</sourceDocumentExtensions>
+									<outputFile>${project.build.directory}/generated-docs/reference/pdf/spring-native-reference.pdf</outputFile>
+									<resources>
+										<resource>
+											<directory>${refdocs.build.directory}</directory>
+											<excludes>
+												<exclude>**/*</exclude>
+											</excludes>
+										</resource>
+									</resources>
 								</configuration>
 							</execution>
 						</executions>

--- a/spring-native/src/main/java/org/springframework/nativex/GeneratedClassNotFoundExceptionFailureAnalyzer.java
+++ b/spring-native/src/main/java/org/springframework/nativex/GeneratedClassNotFoundExceptionFailureAnalyzer.java
@@ -12,7 +12,7 @@ public class GeneratedClassNotFoundExceptionFailureAnalyzer extends AbstractFail
 
 	private static final String ACTION = String.format(
 			"Review your local configuration and make sure that the Spring AOT plugin is configured properly.%n"
-					+ "See https://docs.spring.io/spring-native/docs/current/reference/#spring-aot for more details.");
+					+ "See https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#spring-aot for more details.");
 
 	@Override
 	protected FailureAnalysis analyze(Throwable rootFailure, GeneratedClassNotFoundException ex) {


### PR DESCRIPTION
This restructures the reference guide to harmonize it with other projects. The HTML rendering is now in `/reference/htmlsingle` while the pdf is in `/reference/pdf`. The PDF file was also renamed from `index.pdf` to `spring-native-reference.pdf`.

Various links to the doc were also updated as part of this change. 