### PR TITLE
Restore Bintray plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,11 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</pluginRepository>
+		<pluginRepository>
+			<name>Bintray</name>
+			<id>bintray</id>
+			<url>https://jcenter.bintray.com</url>
+		</pluginRepository>
 	</pluginRepositories>
 
 </project>


### PR DESCRIPTION
This is a refinement of 29ba0272 that removed a plugin repository that's
used by CI to deploy the artifacts.