### PR TITLE
Add anchor for doc sections

### DIFF
--- a/spring-native-docs/src/main/asciidoc/how-to-contribute.adoc
+++ b/spring-native-docs/src/main/asciidoc/how-to-contribute.adoc
@@ -4,6 +4,7 @@
 This section describes how to extend Spring Native.
 You can then {github-prs}[submit pull requests] in order to add support for a specific part of the Spring ecosystem.
 
+[[how-to-contribute-design]]
 === Designing native-friendly Spring libraries
 
 Native support is mostly about making an application and its libraries possible to analyze at build-time to configure what's required or not at runtime.
@@ -17,6 +18,7 @@ Each reflection entry (per constructor/method/field) leads to the creation of a 
 
 The documentation below describes best practices to keep in mind when trying to make Spring code more compatible with native-images.
 
+[[how-to-contribute-configuration-class]]
 === Use `proxyBeanMethods=false` or method parameter injection in `@Configuration` classes
 
 In native applications, `@Bean` annotated methods do not support cross `@Bean` invocations since they require a CGLIB proxy created at runtime.
@@ -59,6 +61,7 @@ It is perfectly fine to use reflection in a native world but it is most optimal 
 * In the static block/fields of a class initialized at build-time
 * In an AOT transformation run as a Spring AOT build plugin
 
+[[how-to-contribute-new-hints]]
 === Contributing new hints
 
 For most cases Spring Native understands how Spring applications operate - how configurations refer to each other, how beans are going to be instantiated, etc.
@@ -99,6 +102,7 @@ Once you are happy with the hints you crafted, you can {github-prs}[submit a pul
 
 Using the <<tracing-agent>> can also be useful an approximation of the required native configuration without having to run too many native builds.
 
+[[how-to-contribute-dynamic-native-configuration]]
 === Dynamic native configuration
 
 ==== Implementing `NativeConfiguration`
@@ -125,6 +129,7 @@ By filtering it means they may programmatically compute that for some spring.fac
 
 These need to be implemented in `spring-aot`. For debugging them using the Maven plugin, you can use `mvnDebug` instead of `mvn` and connect with a JVM remote debugger from your IDE.
 
+[[how-to-contribute-using-container-build-env]]
 === Using container-based build environment
 
 In order to allow easily reproducible builds of `spring-native`, dedicated interactive Docker images are available for local development (tested on Linux and Mac) and are also used in the CI:
@@ -168,6 +173,7 @@ options:
 
 To test the various samples You can also run the root `build.sh` then `build-key-samples.sh` (test only key samples) or `build-samples.sh` (test all samples) from the container.
 
+[[how-to-contribute-scripts]]
 === Scripts
 
 The `native-image` command supports a number of flags for producing information about what is in an image.

--- a/spring-native-docs/src/main/asciidoc/index.adoc
+++ b/spring-native-docs/src/main/asciidoc/index.adoc
@@ -1,7 +1,8 @@
 include::attributes.adoc[]
 = Spring Native documentation
-Version {version} - Andy Clement; Sébastien Deleuze; Filip Hanik; Dave Syer; Esteban Ginez; Jay Bryant; Brian Clozel
+Version {version} - Andy Clement; Sébastien Deleuze; Filip Hanik; Dave Syer; Esteban Ginez; Jay Bryant; Brian Clozel; Stéphane Nicoll
 
+[[overview]]
 == Overview
 
 Spring Native provides support for compiling Spring applications to native executables using the https://www.graalvm.org[GraalVM] {graalvm-native-docs}/[native-image] compiler.
@@ -31,6 +32,7 @@ In practice, the target is to support your Spring applications, almost unmodifie
 
 NOTE: This is work in progress, see the list of <<support,supported features>> for more details.
 
+[[overview-modules]]
 === Modules
 
 Spring Native is composed of the following modules:
@@ -44,6 +46,7 @@ Spring Native is composed of the following modules:
 * `spring-aot-maven-plugin`: Maven plugin that invokes AOT transformations.
 * `samples`: contains various samples that demonstrate features usage and are used as integration tests.
 
+[[getting-started]]
 == Getting Started
 
 There are two main ways to build a Spring Boot native application:
@@ -74,6 +77,7 @@ include::troubleshooting.adoc[]
 
 include::how-to-contribute.adoc[]
 
+[[contact-us]]
 == Contact us
 
 We would love to hear about your successes and failures (with minimal repro projects) through the {github-issues}[project issue tracker].

--- a/spring-native-docs/src/main/asciidoc/native-image-options.adoc
+++ b/spring-native-docs/src/main/asciidoc/native-image-options.adoc
@@ -6,6 +6,7 @@ Spring Native is enabling automatically some of those, and some others especiall
 
 They can be specified using the `BP_BOOT_NATIVE_IMAGE_BUILD_ARGUMENTS` environment variable in Spring Boot plugin if you are using {spring-boot-docs}/html/spring-boot-features.html#boot-features-container-images-buildpacks[Buildpacks support] or using the `<buildArgs></buildArgs>` configuration element if you are using `native-image-maven-plugin`.
 
+[[native-image-options-default]]
 === Options enabled by default
 
 These options are enabled by default when using Spring Native, since they are mandatory to make a Spring application work when compiled as GraalVM native images.
@@ -19,6 +20,7 @@ These options are enabled by default when using Spring Native, since they are ma
 
 Notice that XML and JMX support is disable by default, see options bellow to enable them if needed.
 
+[[native-image-options-useful]]
 === Useful options
 
 * `--verbose` makes image building output more verbose.
@@ -35,6 +37,7 @@ You can find more details in GraalVM https://github.com/oracle/graal/blob/master
 * `--enable-http` enables HTTP support.
 * `--enable-https` enables HTTPS support.
 
+[[native-image-options-unsupported]]
 === Unsupported options
 
 * `--initialize-at-build-time` without class or package specified is not supported since Spring Native for GraalVM is designed to work with runtime class initialization by default (a selected set of classes are enabled at buildtime).

--- a/spring-native-docs/src/main/asciidoc/spring-aot.adoc
+++ b/spring-native-docs/src/main/asciidoc/spring-aot.adoc
@@ -4,6 +4,7 @@
 Spring AOT build plugins are designed to generate and compile sources by taking advantage of the context of your application (classpath, configuration) in order to improve native image compatibility and footprint.
 It is invoked before running your application and tests, and may potentially require additional IDE configuration.
 
+[[spring-aot-maven]]
 === Maven
 
 The plugin should be declared as following:
@@ -50,7 +51,7 @@ Configuration can be performed if needed within the `<configuration>` element, f
 </configuration>
 ----
 
-See <<configuring-spring-aot>> for a list of the configuration options available.
+See <<spring-aot-configuration>> for a list of the configuration options available.
 
 ==== Intellij IDEA
 
@@ -71,6 +72,7 @@ But Eclipse does not support having the same classes in main and test generated 
 
 VSCode uses the same build tooling as Eclipse, so it should work the same.
 
+[[spring-aot-gradle]]
 === Gradle
 
 You can configure the Gradle Spring AOT plugin by declaring first the plugin repositories in your settings.gradle(.kts) file:
@@ -176,9 +178,9 @@ springAot {
 }
 ----
 
-See <<configuring-spring-aot>> for more details on the configuration options.
+See <<spring-aot-configuration>> for more details on the configuration options.
 
-[[configuring-spring-aot]]
+[[spring-aot-configuration]]
 === Configuring Spring AOT
 
 * `mode` switches how much configuration the feature actually provides to the native image compiler:

--- a/spring-native-docs/src/main/asciidoc/support.adoc
+++ b/spring-native-docs/src/main/asciidoc/support.adoc
@@ -3,11 +3,13 @@
 
 This section defines the GraalVM version, languages and dependencies that have been validated against Spring Native {version}.
 
+[[support-graalvm]]
 === GraalVM
 
 GraalVM version {graalvm-version} is supported, see the related https://www.graalvm.org/release-notes/[release notes].
 GraalVM issues impacting the Spring ecosystem are identified on their issue tracker using https://github.com/oracle/graal/labels/spring[the `spring` label].
 
+[[support-language]]
 === Language
 
 Java 8, Java 11, and Kotlin 1.3+ are supported.
@@ -16,11 +18,13 @@ NOTE: Java 11 native images are currently impacted by a transient footprint issu
 
 Kotlin Coroutines are supported but require additional reflection entries due to how Coroutines generates bytecode with an `Object` return type, see https://github.com/spring-projects/spring-framework/issues/21546[this related issue] for a potential future fix.
 
+[[support-feature-flags]]
 === Feature flags
 
 Some features like HTTPS may require some additional flags, check <<native-image-options>> for more details.
 When it recognizes certain usage scenarios, Spring Native tries to set required flags automatically.
 
+[[support-spring-boot]]
 === Spring Boot
 
 IMPORTANT: `spring-native` {version} is designed to be used with Spring Boot {spring-boot-version}.
@@ -59,6 +63,7 @@ RSocket security is also supported.
 IMPORTANT: Devtools is not supported yet, you can follow
 https://github.com/spring-projects-experimental/spring-native/issues/532[spring-native#532] to be aware when it will.
 
+[[support-spring-cloud]]
 === Spring Cloud
 
 IMPORTANT: `spring-native` {version} is designed to be used with Spring Cloud {spring-cloud-version}.
@@ -76,6 +81,7 @@ NOTE: When using Spring Native, `spring.cloud.refresh.enabled` is set to `false`
 * `spring-cloud-starter-function-webflux`
 ** `--enable-https` flag is required for HTTPS support.
 
+[[support-others]]
 === Others
 
 * Spring Kafka
@@ -84,6 +90,7 @@ NOTE: When using Spring Native, `spring.cloud.refresh.enabled` is set to `false`
 * Mysql JDBC driver
 * PostgreSQL JDBC driver
 
+[[support-limitations]]
 === Limitations
 
 CGLIB proxies are not supported, only JDK dynamic proxies on interfaces are supported for now. As a consequence `spring.aop.proxy-target-class` is set to `false` when using Spring Native.

--- a/spring-native-docs/src/main/asciidoc/tracing-agent.adoc
+++ b/spring-native-docs/src/main/asciidoc/tracing-agent.adoc
@@ -10,6 +10,7 @@ The first option is certainly quick but rather manual/tedious.
 The second option sounds much more appealing for a robust/repeatable setup but by default the generated configuration will include anything required by the test infrastructure, which is unnecessary when the application runs for real.
 To address this problem the agent supports an access-filter file that will cause certain data to be excluded from the generated output.
 
+[[tracing-agent-testing]]
 === Testing with the agent to compute configuration
 
 ==== A basic access-filter file

--- a/spring-native-docs/src/main/asciidoc/troubleshooting.adoc
+++ b/spring-native-docs/src/main/asciidoc/troubleshooting.adoc
@@ -9,6 +9,7 @@ This section explores some of the errors that can be encountered and possible fi
 
 Make sure to check https://github.com/oracle/graal/projects/2?card_filter_query=label%3Aspring[GraalVM native image known issues related to Spring] as well as https://github.com/spring-projects-experimental/spring-native/issues[Spring Native open issues] before creating a new one.
 
+[[troubleshooting-native-image-failing]]
 === `native-image` is failing
 
 The image can fail for a number of reasons.
@@ -38,6 +39,7 @@ See this https://stackoverflow.com/questions/44533319/how-to-assign-more-memory-
 
 On Windows, make sure to enable the https://docs.docker.com/docker-for-windows/wsl/[Docker WSL 2 backend] for better performances.
 
+[[troubleshooting-image-does-not-run]]
 === The built image does not run
 
 If your built image does not run, you can try a number of fixes.
@@ -89,6 +91,7 @@ you can temporarily turn this hard error into a warning since it is possible tha
 To do so, specify the `failOnMissingSelectorHint` option to `false` to cause log messages about the problem but not a hard fail.
 Note that using warnings rather than errors can cause serious problems for your application.
 
+[[troubleshooting-working-with-snapshots]]
 === Working with snapshots
 
 Snapshots are regularly published and obviously ahead of releases and milestones.


### PR DESCRIPTION
This is quite useful if you need to link to a particular section of the ref guide as the auto-generated anchor can change if we rename the title of the section.