### PR TITLE
 DB_HOST variable to connect to mySQL

### DIFF
--- a/samples/petclinic-jpa/docker-compose.yml
+++ b/samples/petclinic-jpa/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - ./src/main/resources/db/mysql/data.sql:/docker-entrypoint-initdb.d/2-data.sql
   petclinic-jpa:
     image: petclinic-jpa:0.0.1-SNAPSHOT
+    environment:
+      - DB_HOST=mysql-server
     ports:
       - "8080:8080"
     depends_on:

--- a/samples/petclinic-jpa/src/main/resources/application.properties
+++ b/samples/petclinic-jpa/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # database init, supports mysql too
 database=mysql
-spring.datasource.url=jdbc:mysql://localhost/petclinic?serverTimezone=UTC&useUnicode=yes&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}/petclinic?serverTimezone=UTC&useUnicode=yes&characterEncoding=UTF-8
 spring.datasource.initialization-mode=never
 spring.datasource.username=petclinic
 spring.datasource.password=petclinic


### PR DESCRIPTION
This PR add a DB_HOST env var so that the location of the MySQL host can be changed easily. 

Today the app tries to connect to `localhost` always and the docker compose provides mysql at `mysql-server:3306`

using localhost will work for MySQL when 
- the mysql container is running 
- ports are mapped to  localhost
- the sample is run as a local process (not a container) - the `build.sh` seems to do this. 

If this PR is acceptable, I can update the other samples as well.

 
