### PR TITLE
Polish ci

### DIFF
--- a/ci/README.adoc
+++ b/ci/README.adoc
@@ -11,7 +11,7 @@ The pipeline can be deployed using the following command:
 
 [source]
 ----
-$ fly -t spring-native set-pipeline -p spring-native -c ci/pipeline.yml
+$ fly -t spring-native set-pipeline -p spring-native -c ci/pipeline.yml -l ci/parameters.yml
 ----
 
 NOTE: This assumes that you have configured the appropriate secrets.

--- a/ci/build-key-samples.sh
+++ b/ci/build-key-samples.sh
@@ -5,6 +5,6 @@ native-image --version
 if [[ -n $DOCKER_HUB_USERNAME ]]; then
 	echo "$DOCKER_HUB_PASSWORD" | docker login -u $DOCKER_HUB_USERNAME --password-stdin
 fi
-cd spring-native
+cd git-repo
 ./build.sh
 ./build-key-samples.sh

--- a/ci/build-samples.sh
+++ b/ci/build-samples.sh
@@ -6,7 +6,7 @@ native-image --version
 if [[ -n $DOCKER_HUB_USERNAME ]]; then
   echo "$DOCKER_HUB_PASSWORD" | docker login -u $DOCKER_HUB_USERNAME --password-stdin
 fi
-cd spring-native
+cd git-repo
 if ! (./build.sh); then
     RC=1
 fi

--- a/ci/config/changelog-generator.yml
+++ b/ci/config/changelog-generator.yml
@@ -1,0 +1,23 @@
+changelog:
+  repository: spring-projects-experimental/spring-native
+  sections:
+    - title: ":star: New Features"
+      labels:
+        - "type: enhancement"
+    - title: ":star: Compatibility"
+      labels:
+        - "type: compatibility"
+    - title: ":star: Optimizations"
+      labels:
+        - "type: optimization"
+    - title: ":beetle: Bug Fixes"
+      labels:
+        - "type: bug"
+        - "type: regression"
+    - title: ":notebook_with_decorative_cover: Documentation"
+      labels:
+        - "type: documentation"
+    - title: ":hammer: Dependency Upgrades"
+      sort: "title"
+      labels:
+        - "type: dependency-upgrade"

--- a/ci/config/release-scripts.yml
+++ b/ci/config/release-scripts.yml
@@ -1,0 +1,10 @@
+logging:
+  level:
+    io.spring.concourse: DEBUG
+spring:
+  main:
+    banner-mode: off
+sonatype:
+  exclude:
+    - 'build-info\.json'
+    - '.*\.zip'

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-cd spring-native
-./mvnw -ntp deploy -P artifactory,docs -Dartifactory.username=$ARTIFACTORY_USERNAME -Dartifactory.password=$ARTIFACTORY_PASSWORD

--- a/ci/images/README.adoc
+++ b/ci/images/README.adoc
@@ -1,0 +1,21 @@
+== CI Images
+
+These images are used by CI to run the actual builds.
+
+To build the image locally run the following from this directory:
+
+----
+$ docker build --no-cache -f <image-folder>/Dockerfile .
+----
+
+For example
+
+----
+$ docker build --no-cache -f ci-image/Dockerfile .
+----
+
+To test run:
+
+----
+$ docker run -it --entrypoint /bin/bash <SHA>
+----

--- a/ci/images/ci-image/Dockerfile
+++ b/ci/images/ci-image/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:focal-20210217
+
+ADD setup.sh /setup.sh
+ADD get-jdk-url.sh /get-jdk-url.sh
+RUN ./setup.sh java11
+
+ENV JAVA_HOME /opt/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH

--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+	java11)
+		 echo "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz"
+	;;
+	*)
+		echo $"Unknown java version"
+		exit 1
+esac

--- a/ci/images/setup.sh
+++ b/ci/images/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+###########################################################
+# UTILS
+###########################################################
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install --no-install-recommends -y tzdata ca-certificates net-tools libxml2-utils git curl libudev1 libxml2-utils iptables iproute2 jq unzip
+ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+dpkg-reconfigure --frontend noninteractive tzdata
+rm -rf /var/lib/apt/lists/*
+
+curl https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v0.0.4/concourse-java.sh > /opt/concourse-java.sh
+
+curl --output /opt/concourse-release-scripts.jar https://repo.spring.io/release/io/spring/concourse/releasescripts/concourse-release-scripts/0.3.1/concourse-release-scripts-0.3.1.jar
+
+###########################################################
+# JAVA
+###########################################################
+JDK_URL=$( ./get-jdk-url.sh $1 )
+
+mkdir -p /opt/openjdk
+cd /opt/openjdk
+curl -L ${JDK_URL} | tar zx --strip-components=1
+test -f /opt/openjdk/bin/java
+test -f /opt/openjdk/bin/javac

--- a/ci/parameters.yml
+++ b/ci/parameters.yml
@@ -1,0 +1,9 @@
+github-repo: "https://github.com/spring-projects-experimental/spring-native.git"
+github-repo-name: "spring-projects-experimental/spring-native"
+docker-hub-organization: "springci"
+artifactory-server: "https://repo.spring.io"
+branch: "master"
+milestone: "0.9.x"
+build-name: "spring-native"
+concourse-url: "https://ci.spring.io"
+task-timeout: 30m

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,7 +1,29 @@
 anchors:
+  artifactory-repo-put-params: &artifactory-repo-put-params
+    repo: libs-snapshot-local
+    folder: distribution-repository
+    build_uri: "https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+    build_number: "${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-${BUILD_NAME}"
+    disable_checksum_uploads: true
+    exclude:
+      - "**/*.effective-pom"
+      - "*/spring-native-docs-*.jar"
+    artifactory-task-params: &artifactory-task-params
+      ARTIFACTORY_SERVER: ((artifactory-server))
+      ARTIFACTORY_USERNAME: ((artifactory-username))
+      ARTIFACTORY_PASSWORD: ((artifactory-password))
   docker-hub-task-params: &docker-hub-task-params
     DOCKER_HUB_USERNAME: ((docker-hub-username))
     DOCKER_HUB_PASSWORD: ((docker-hub-password))
+  git-repo-resource-source: &git-repo-resource-source
+    uri: ((github-repo))
+    username: ((github-username))
+    password: ((github-password))
+    branch: ((branch))
+  registry-image-resource-source: &registry-image-resource-source
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))
+    tag: ((milestone))
   slack-fail-params: &slack-fail-params
     text: >
       :concourse-failed: <https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME} ${BUILD_JOB_NAME} failed!>
@@ -9,17 +31,42 @@ anchors:
     icon_emoji: ":concourse:"
     username: concourse-ci
 resource_types:
+  - name: artifactory-resource
+    type: registry-image
+    source:
+      repository: springio/artifactory-resource
+      tag: 0.0.14
   - name: slack-notification
     type: docker-image
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest
 resources:
-  - name: spring-native
+  - name: git-repo
     type: git
+    icon: github
     source:
-      uri: https://github.com/spring-projects-experimental/spring-native
-      branch: master
+      <<: *git-repo-resource-source
+  - name: ci-images-git-repo
+    type: git
+    icon: github
+    source:
+      <<: *git-repo-resource-source
+      paths: ["ci/images/*"]
+  - name: ci-image
+    type: docker-image
+    icon: docker
+    source:
+      <<: *registry-image-resource-source
+      repository: ((docker-hub-organization))/spring-native-ci
+  - name: artifactory-repo
+    type: artifactory-resource
+    icon: package-variant
+    source:
+      uri: ((artifactory-server))
+      username: ((artifactory-username))
+      password: ((artifactory-password))
+      build_name: ((build-name))
   - name: slack-alert
     type: slack-notification
     icon: slack
@@ -29,10 +76,19 @@ resources:
     type: time
     source: {interval: 24h}
 jobs:
+  - name: build-ci-image
+    plan:
+      - get: ci-images-git-repo
+        trigger: true
+      - in_parallel:
+          - put: ci-image
+            params:
+              build: ci-images-git-repo/ci/images
+              dockerfile: ci-images-git-repo/ci/images/ci-image/Dockerfile
   - name: build-java8-key-samples
     public: true
     plan:
-    - get: spring-native
+    - get: git-repo
       trigger: true
     - task: build
       privileged: true
@@ -46,13 +102,13 @@ jobs:
             repository: springci/spring-native
             tag: 21.0-dev-java8
         inputs:
-          - name: spring-native
+          - name: git-repo
         run:
-          path: spring-native/ci/build-key-samples.sh
+          path: git-repo/ci/build-key-samples.sh
   - name: build-java11-key-samples
     public: true
     plan:
-      - get: spring-native
+      - get: git-repo
         trigger: true
       - task: build
         privileged: true
@@ -66,14 +122,14 @@ jobs:
               repository: springci/spring-native
               tag: 21.0-dev-java11
           inputs:
-            - name: spring-native
+            - name: git-repo
           run:
-            path: spring-native/ci/build-key-samples.sh
+            path: git-repo/ci/build-key-samples.sh
   - name: build-21.0-dev-java8-samples
     old_name: build-20.3-dev-java8-samples
     public: true
     plan:
-      - get: spring-native
+      - get: git-repo
       - get: every-day
         trigger: true
       - task: build
@@ -88,14 +144,14 @@ jobs:
               repository: springci/spring-native
               tag: 21.0-dev-java8
           inputs:
-            - name: spring-native
+            - name: git-repo
           run:
-            path: spring-native/ci/build-samples.sh
+            path: git-repo/ci/build-samples.sh
   - name: build-21.0-dev-java11-samples
     old_name: build-20.3-dev-java11-samples
     public: true
     plan:
-      - get: spring-native
+      - get: git-repo
       - get: every-day
         trigger: true
       - do:
@@ -111,9 +167,9 @@ jobs:
                 repository: springci/spring-native
                 tag: 21.0-dev-java11
             inputs:
-              - name: spring-native
+              - name: git-repo
             run:
-              path: spring-native/ci/build-samples.sh
+              path: git-repo/ci/build-samples.sh
         on_failure:
           do:
             - put: slack-alert
@@ -122,7 +178,7 @@ jobs:
   - name: build-master-java8-samples
     public: true
     plan:
-      - get: spring-native
+      - get: git-repo
       - get: every-day
         trigger: true
       - task: build
@@ -137,13 +193,13 @@ jobs:
               repository: springci/spring-native
               tag: master-java8
           inputs:
-            - name: spring-native
+            - name: git-repo
           run:
-            path: spring-native/ci/build-samples.sh
+            path: git-repo/ci/build-samples.sh
   - name: build-master-java11-samples
     public: true
     plan:
-      - get: spring-native
+      - get: git-repo
       - get: every-day
         trigger: true
       - task: build
@@ -158,32 +214,26 @@ jobs:
               repository: springci/spring-native
               tag: master-java11
           inputs:
-            - name: spring-native
+            - name: git-repo
           run:
-            path: spring-native/ci/build-samples.sh
+            path: git-repo/ci/build-samples.sh
   - name: deploy
     public: true
     plan:
-      - get: spring-native
+      - get: ci-image
+      - get: git-repo
         passed:
           - build-java8-key-samples
           - build-java11-key-samples
         trigger: true
-      - task: deploy
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: openjdk
-              tag: 11-jdk
-          inputs:
-            - name: spring-native
-          run:
-            path: spring-native/ci/deploy.sh
+      - task: build-project
+        image: ci-image
+        privileged: true
+        timeout: ((task-timeout))
+        file: git-repo/ci/tasks/build-project.yml
+      - put: artifactory-repo
         params:
-          ARTIFACTORY_USERNAME: ((artifactory-username))
-          ARTIFACTORY_PASSWORD: ((artifactory-password))
+          <<: *artifactory-repo-put-params
 groups:
   - name: "each-commit-builds"
     jobs: [
@@ -196,3 +246,5 @@ groups:
       "build-21.0-dev-java11-samples",
       "build-master-java8-samples",
       "build-master-java11-samples"]
+  - name: "ci-images"
+    jobs: ["build-ci-image"]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,6 +67,14 @@ resources:
       username: ((artifactory-username))
       password: ((artifactory-password))
       build_name: ((build-name))
+  - name: github-release
+    type: github-release
+    icon: briefcase-download
+    source:
+      owner: spring-io
+      repository: initializr
+      access_token: ((github-ci-release-token))
+      pre_release: false
   - name: slack-alert
     type: slack-notification
     icon: slack
@@ -234,6 +242,64 @@ jobs:
       - put: artifactory-repo
         params:
           <<: *artifactory-repo-put-params
+  - name: stage-release
+    serial: true
+    plan:
+      - get: ci-image
+      - get: git-repo
+        trigger: false
+      - task: stage
+        image: ci-image
+        file: git-repo/ci/tasks/stage.yml
+        params:
+          RELEASE_TYPE: RELEASE
+      - put: artifactory-repo
+        params:
+          <<: *artifactory-repo-put-params
+          repo: libs-staging-local
+      - put: git-repo
+        params:
+          repository: stage-git-repo
+  - name: promote-release
+    serial: true
+    plan:
+      - get: ci-image
+      - get: git-repo
+        trigger: false
+      - get: artifactory-repo
+        trigger: false
+        passed: [ stage-release ]
+        params:
+          download_artifacts: true
+          save_build_info: true
+      - task: promote
+        image: ci-image
+        file: git-repo/ci/tasks/promote.yml
+        params:
+          RELEASE_TYPE: RELEASE
+          <<: *artifactory-task-params
+  - name: create-github-release
+    serial: true
+    plan:
+      - get: ci-image
+      - get: git-repo
+      - get: artifactory-repo
+        trigger: true
+        passed: [ promote-release ]
+        params:
+          download_artifacts: false
+          save_build_info: true
+      - task: generate-changelog
+        file: git-repo/ci/tasks/generate-changelog.yml
+        params:
+          RELEASE_TYPE: RELEASE
+          GITHUB_USERNAME: ((github-username))
+          GITHUB_TOKEN: ((github-ci-release-token))
+      - put: github-release
+        params:
+          name: generated-changelog/tag
+          tag: generated-changelog/tag
+          body: generated-changelog/changelog.md
 groups:
   - name: "each-commit-builds"
     jobs: [
@@ -246,5 +312,7 @@ groups:
       "build-21.0-dev-java11-samples",
       "build-master-java8-samples",
       "build-master-java11-samples"]
+  - name: "releases"
+    jobs: ["stage-release", "promote-release", "create-github-release"]
   - name: "ci-images"
     jobs: ["build-ci-image"]

--- a/ci/scripts/build-project.sh
+++ b/ci/scripts/build-project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/common.sh
+repository=$(pwd)/distribution-repository
+if [ -z "$(ls -A maven)" ]; then
+   echo "Maven cache not available."
+else
+   echo "Maven cache found."
+fi
+pushd git-repo > /dev/null
+./mvnw clean deploy -U -Pdocs -DaltDeploymentRepository=distribution::default::file://${repository}
+popd > /dev/null

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -1,0 +1,4 @@
+source /opt/concourse-java.sh
+
+setup_symlinks
+cleanup_maven_repo "org.springframework.experimental"

--- a/ci/scripts/generate-changelog.sh
+++ b/ci/scripts/generate-changelog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+CONFIG_DIR=git-repo/ci/config
+version=$( cat artifactory-repo/build-info.json | jq -r '.buildInfo.modules[0].id' | sed 's/.*:.*:\(.*\)/\1/' )
+
+java -jar /github-changelog-generator.jar \
+  --spring.config.location=${CONFIG_DIR}/changelog-generator.yml \
+  ${version} generated-changelog/changelog.md
+
+echo ${version} > generated-changelog/version
+echo v${version} > generated-changelog/tag

--- a/ci/scripts/promote.sh
+++ b/ci/scripts/promote.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source $(dirname $0)/common.sh
+CONFIG_DIR=git-repo/ci/config
+
+version=$( cat artifactory-repo/build-info.json | jq -r '.buildInfo.modules[0].id' | sed 's/.*:.*:\(.*\)/\1/' )
+export BUILD_INFO_LOCATION=$(pwd)/artifactory-repo/build-info.json
+
+java -jar /opt/concourse-release-scripts.jar \
+  --spring.config.location=${CONFIG_DIR}/release-scripts.yml \
+  promote $RELEASE_TYPE $BUILD_INFO_LOCATION || { exit 1; }
+
+echo "Promotion complete"
+echo $version > version/version

--- a/ci/scripts/stage.sh
+++ b/ci/scripts/stage.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/common.sh
+repository=$(pwd)/distribution-repository
+
+pushd git-repo > /dev/null
+git fetch --tags --all > /dev/null
+popd > /dev/null
+
+git clone git-repo stage-git-repo > /dev/null
+
+pushd stage-git-repo > /dev/null
+
+snapshotVersion=$( get_revision_from_pom )
+stageVersion=$( get_next_release $snapshotVersion)
+nextVersion=$( bump_version_number $snapshotVersion)
+echo "Staging $stageVersion (next version will be $nextVersion)"
+
+set_revision_to_pom "$stageVersion"
+git config user.name "Spring Buildmaster" > /dev/null
+git config user.email "buildmaster@springframework.org" > /dev/null
+git add pom.xml > /dev/null
+git commit -m"Release v$stageVersion" > /dev/null
+git tag -a "v$stageVersion" -m"Release v$stageVersion" > /dev/null
+
+./mvnw clean deploy -U -Pdocs -DaltDeploymentRepository=distribution::default::file://${repository}
+
+git reset --hard HEAD^ > /dev/null
+if [[ $nextVersion != $snapshotVersion ]]; then
+	echo "Setting next development version (v$nextVersion)"
+	set_revision_to_pom "$nextVersion"
+	git add pom.xml > /dev/null
+	git commit -m"Next development version (v$nextVersion)" > /dev/null
+fi;
+
+echo "DONE"
+
+popd > /dev/null

--- a/ci/tasks/build-project.yml
+++ b/ci/tasks/build-project.yml
@@ -1,0 +1,10 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+outputs:
+- name: distribution-repository
+caches:
+- path: maven
+run:
+  path: git-repo/ci/scripts/build-project.sh

--- a/ci/tasks/generate-changelog.yml
+++ b/ci/tasks/generate-changelog.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: springio/github-changelog-generator
+    tag: '0.0.6'
+inputs:
+  - name: git-repo
+  - name: artifactory-repo
+outputs:
+  - name: generated-changelog
+params:
+  GITHUB_ORGANIZATION:
+  GITHUB_REPO:
+  GITHUB_USERNAME:
+  GITHUB_TOKEN:
+  RELEASE_TYPE:
+run:
+  path: git-repo/ci/scripts/generate-changelog.sh

--- a/ci/tasks/promote.yml
+++ b/ci/tasks/promote.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+- name: artifactory-repo
+outputs:
+- name: version
+params:
+  ARTIFACTORY_SERVER:
+  ARTIFACTORY_USERNAME:
+  ARTIFACTORY_PASSWORD:
+run:
+  path: git-repo/ci/scripts/promote.sh

--- a/ci/tasks/stage.yml
+++ b/ci/tasks/stage.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+outputs:
+- name: stage-git-repo
+- name: distribution-repository
+caches:
+- path: maven
+run:
+  path: git-repo/ci/scripts/stage.sh

--- a/pom.xml
+++ b/pom.xml
@@ -250,49 +250,6 @@
 		</pluginManagement>
 	</build>
 
-	<profiles>
-		<profile>
-			<id>artifactory</id>
-			<build>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.jfrog.buildinfo</groupId>
-							<artifactId>artifactory-maven-plugin</artifactId>
-							<version>2.7.0</version>
-							<executions>
-								<execution>
-									<id>build-info</id>
-									<goals>
-										<goal>publish</goal>
-									</goals>
-									<configuration>
-										<publisher>
-											<contextUrl>https://repo.spring.io</contextUrl>
-											<username>${artifactory.username}</username>
-											<password>${artifactory.password}</password>
-											<repoKey>libs-release-local</repoKey>
-											<snapshotRepoKey>libs-snapshot-local</snapshotRepoKey>
-											<excludePatterns>*/spring-native-docs-*.jar</excludePatterns>
-										</publisher>
-									</configuration>
-								</execution>
-							</executions>
-						</plugin>
-					</plugins>
-				</pluginManagement>
-
-				<plugins>
-					<plugin>
-						<groupId>org.jfrog.buildinfo</groupId>
-						<artifactId>artifactory-maven-plugin</artifactId>
-					</plugin>
-				</plugins>
-
-			</build>
-		</profile>
-	</profiles>
-
 	<repositories>
 		<repository>
 			<id>spring-snapshot</id>

--- a/spring-native-docs/pom.xml
+++ b/spring-native-docs/pom.xml
@@ -82,6 +82,11 @@
 								<artifactId>spring-asciidoctor-extensions-block-switch</artifactId>
 								<version>0.5.0</version>
 							</dependency>
+							<dependency>
+								<groupId>org.jruby</groupId>
+								<artifactId>jruby-complete</artifactId>
+								<version>9.1.17.0</version>
+							</dependency>
 						</dependencies>
 						<configuration>
 							<sourceDirectory>${refdocs.build.directory}</sourceDirectory>


### PR DESCRIPTION
This PR harmonizes the main build to use a custom CI image that can be reused for other tasks  (i.e. releasing).

A new CI group that allows to perform a release has been added. First, a staging build is pushed to `libs-staging-local`. Then, a promotion job can be invoked once the bits have been verified.

For the moment, only a local promotion is performed that triggers the automatic generation of the changelog.