### PR TITLE
Fix pom publication with shaded artifact

### DIFF
--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -94,6 +94,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<relocations>
 								<relocation>
 									<pattern>org.objectweb.asm</pattern>

--- a/spring-native-tools/pom.xml
+++ b/spring-native-tools/pom.xml
@@ -37,6 +37,7 @@
 					</execution>
 				</executions>
 				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
 					<filters>
 						<filter>
 							<artifact>*:*</artifact>


### PR DESCRIPTION
This commit disables the reduced poms created by the shade plugin that
trumps the property placeholder resolution for `${revision}`