### PR TITLE
Fixes inconsistent proxy registration on successive runs.

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
@@ -89,6 +89,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Andy Clement
  * @author Christoph Strobl
+ * @author Jens Schauder
  */ 
 public class SpringDataComponentProcessor implements ComponentProcessor {
 	
@@ -163,10 +164,7 @@ public class SpringDataComponentProcessor implements ComponentProcessor {
 
 	@Override
 	public boolean handle(NativeContext imageContext, String key, List<String> values) {
-		if (repositoryName != null && values.contains(repositoryName)) {
-			return !keysSeen.contains(key);
-		}
-		return false;
+		return repositoryName != null && values.contains(repositoryName);
 	}
 
 	@Override


### PR DESCRIPTION
The `SpringDataComponentProcessor` didn't handle successive identical events. Due to a yet to fix problem it got called multiple times in some scenarios, which in turn resulted in it not properly registering proxies for repositories.