### PR TITLE
Fix Spring Data custom repository fragment lookup.

### DIFF
--- a/samples/data-elasticsearch/src/main/java/com/example/data/elasticsearch/CLR.java
+++ b/samples/data-elasticsearch/src/main/java/com/example/data/elasticsearch/CLR.java
@@ -20,9 +20,11 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchPage;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.Criteria;
@@ -70,6 +72,13 @@ public class CLR implements CommandLineRunner {
 					.keywords(Arrays.asList("java", "spring")).location(new GeoPoint(50.0646501D, 19.9449799)).build());
 
 			System.out.println("repository.count(): " + repository.count());
+		}
+
+		{
+			System.out.println("\n--- CUSTOM REPOSITORY ---");
+
+			SearchPage<Conference> searchPage = repository.findBySomeCustomImplementation("eXchange", PageRequest.of(0, 10));
+			System.out.println("custom implementation finder.size(): " + searchPage.getSearchHits().getTotalHits());
 		}
 
 		String expectedDate = "2014-10-29";

--- a/samples/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ConferenceCustomRepository.java
+++ b/samples/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ConferenceCustomRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package com.example.data.elasticsearch;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchPage;
 
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+public interface ConferenceCustomRepository {
 
-interface ConferenceRepository extends ElasticsearchRepository<Conference, String>, ConferenceCustomRepository {
-
-	List<Conference> findByKeywordsContaining(String keyword);
+	SearchPage<Conference> findBySomeCustomImplementation(String name, Pageable page);
 }

--- a/samples/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ConferenceCustomRepositoryImpl.java
+++ b/samples/data-elasticsearch/src/main/java/com/example/data/elasticsearch/ConferenceCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.elasticsearch;
+
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Indexed;
+
+@Indexed
+@Component // required for spring.components
+public class ConferenceCustomRepositoryImpl implements ConferenceCustomRepository {
+
+	private final ElasticsearchOperations operations;
+
+	public ConferenceCustomRepositoryImpl(ElasticsearchOperations operations) {
+		this.operations = operations;
+	}
+
+	@Override
+	public SearchPage<Conference> findBySomeCustomImplementation(String name, Pageable page) {
+
+		Query query = new NativeSearchQueryBuilder()
+				.withQuery(QueryBuilders.matchQuery("name", name))
+				.build();
+
+		SearchHits<Conference> searchHits = operations.search(query, Conference.class);
+		return SearchHitSupport.searchPageFor(searchHits, page);
+	}
+}

--- a/spring-native-configuration/src/main/java/org/springframework/data/SpringDataCommonsHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/SpringDataCommonsHints.java
@@ -27,6 +27,7 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.data.repository.core.support.RepositoryFragment;
 import org.springframework.data.repository.core.support.RepositoryFragmentsFactoryBean;
 import org.springframework.data.repository.core.support.TransactionalRepositoryFactoryBeanSupport;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
@@ -43,6 +44,7 @@ import org.springframework.nativex.hint.AccessBits;
 				@TypeHint(types = {
 						RepositoryFactoryBeanSupport.class,
 						RepositoryFragmentsFactoryBean.class,
+						RepositoryFragment.class,
 						TransactionalRepositoryFactoryBeanSupport.class,
 						QueryByExampleExecutor.class,
 						MappingContext.class,

--- a/spring-native/src/main/java/org/springframework/nativex/substitutions/data/Target_CustomRepositoryImplementationDetector.java
+++ b/spring-native/src/main/java/org/springframework/nativex/substitutions/data/Target_CustomRepositoryImplementationDetector.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.substitutions.data;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ScannedGenericBeanDefinition;
+import org.springframework.context.index.CandidateComponentsIndex;
+import org.springframework.context.index.CandidateComponentsIndexLoader;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.data.repository.config.ImplementationDetectionConfiguration;
+import org.springframework.nativex.substitutions.OnlyIfPresent;
+import org.springframework.stereotype.Component;
+
+
+@TargetClass(className = "org.springframework.data.repository.config.CustomRepositoryImplementationDetector", onlyWith = {OnlyIfPresent.class})
+public final class Target_CustomRepositoryImplementationDetector {
+
+	@Substitute
+	private Set<BeanDefinition> findCandidateBeanDefinitions(ImplementationDetectionConfiguration config) {
+
+		/* Using the index instead of ClassPathScanningCandidateComponentProvider with pattern.
+		 * Not sure why components are not found via the index as it should be configured on
+		 * `setResourceLoader` within ClassPathScanningCandidateComponentProvider.
+		 *
+		 * ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false, environment);
+		 *
+		 * provider.setResourceLoader(resourceLoader);
+		 * provider.setResourcePattern(String.format(CUSTOM_IMPLEMENTATION_RESOURCE_PATTERN, postfix));
+		 * provider.setMetadataReaderFactory(config.getMetadataReaderFactory());
+		 * provider.addIncludeFilter((reader, factory) -> true);
+		 */
+		CandidateComponentsIndex index = CandidateComponentsIndexLoader.loadIndex(config.getClass().getClassLoader());
+
+		return config.getBasePackages().stream()
+
+				.flatMap(new Function<String, Stream<? extends BeanDefinition>>() { // see oracle/graal#2479
+
+							 @Override
+							 public Stream<? extends BeanDefinition> apply(String basePackage) {
+
+								 Set<String> candidateTypes = index.getCandidateTypes(basePackage, Component.class.getName());
+								 if (candidateTypes.isEmpty()) {
+									 return Stream.empty();
+								 }
+
+								 Set<BeanDefinition> beanDefinitions = new LinkedHashSet<>();
+								 for (String candidate : candidateTypes) {
+									 if (candidate.endsWith(config.getImplementationPostfix())) {
+
+										 try {
+
+											 MetadataReader metadataReader = config.getMetadataReaderFactory().getMetadataReader(candidate);
+											 ScannedGenericBeanDefinition sbd = new ScannedGenericBeanDefinition(metadataReader);
+											 sbd.setResource(metadataReader.getResource());
+											 beanDefinitions.add(sbd);
+										 } catch (IOException ex) {
+											 throw new BeanDefinitionStoreException(String.format("Failure while reading metadata for %s.", candidate), ex);
+										 }
+									 }
+								 }
+
+								 return beanDefinitions.stream();
+							 }
+						 }
+				).collect(Collectors.toSet());
+	}
+}


### PR DESCRIPTION
This commit introduces a `Substitution` for the Spring Data `CustomRepositoryImplementationDetector` to directly use the `CandidateComponentsIndex` for repository fragment lookups and adds the missing type hint for the `RepositoryFragment` required to create the target repository.

This enables fragments following the pattern `FragmentInterfaceName` | `FragmentInterfaceNameImpl` to be discovered and registered correctly when annotated with `@Component` as outlined below.

```java
interface CustomRepository {
	// ... 
}

@Component
class CustomRepositoryImpl implements CustomRepository {
	// ... 
}

interface DomainTypeRepository extends CrudRepository<DomainType, String>, CustomRepository {
	// ... 
}
```

It also updates the data-elasticsearch example to cover the custom repository setup and retains functionality of the heritage configuration format (used in the data-mongodb).

On the long run it would be beneficial to revisit the `ClassPathScanningCandidateComponentProvider` for bean lookups using the `spring.components` index so it supports the in this PR substituted lookup.

----

Closes: #639 