### PR TITLE
Fix query derivation for 1:N and 1:1 relationships.

### DIFF
--- a/samples/data-jpa/src/main/java/app/main/SampleApplication.java
+++ b/samples/data-jpa/src/main/java/app/main/SampleApplication.java
@@ -1,24 +1,25 @@
 package app.main;
 
-import java.util.Optional;
-
+import app.main.model.Flurb;
 import app.main.model.Foo;
 import app.main.model.FooRepository;
-
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.servlet.function.RouterFunction;
 
-import static org.springframework.web.servlet.function.RequestPredicates.GET;
-import static org.springframework.web.servlet.function.RouterFunctions.route;
-import static org.springframework.web.servlet.function.ServerResponse.ok;
+import java.util.Optional;
+
+import static org.springframework.web.servlet.function.RequestPredicates.*;
+import static org.springframework.web.servlet.function.RouterFunctions.*;
+import static org.springframework.web.servlet.function.ServerResponse.*;
 
 @SpringBootApplication
 public class SampleApplication {
 
-	private FooRepository entities;
+	private final FooRepository entities;
 
 	public SampleApplication(FooRepository entities) {
 		this.entities = entities;
@@ -27,10 +28,15 @@ public class SampleApplication {
 	@Bean
 	public CommandLineRunner runner() {
 		return args -> {
-				Optional<Foo> foo = entities.findById(1L);
-				if (!foo.isPresent()) {
-					entities.save(new Foo("Hello"));
-				}
+
+			Optional<Foo> maybeFoo = entities.findById(1L);
+			Foo foo;
+			foo = maybeFoo.orElseGet(() -> entities.save(new Foo("Hello")));
+			Flurb flurb = new Flurb();
+			flurb.setValue("Balla balla");
+			foo.setFlurb(flurb);
+			entities.save(foo);
+
 			entities.findWithBetween("a", "X");
 		};
 	}
@@ -47,5 +53,4 @@ public class SampleApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(SampleApplication.class, args);
 	}
-
 }

--- a/samples/data-jpa/src/main/java/app/main/model/Flurb.java
+++ b/samples/data-jpa/src/main/java/app/main/model/Flurb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,19 @@
  */
 package app.main.model;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.NoRepositoryBean;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
-import java.util.List;
+@Entity
+public class Flurb {
+	@Id
+	@GeneratedValue
+	Long id;
 
-/**
- * @author Dave Syer
- */
-public interface FooRepository extends JpaRepository<Foo, Long> {
-	@Query("select f from Foo f where f.value between :min and :max")
-	List<Foo> findWithBetween(String min, String max);
+	String value;
 
-	Foo findFirstByFlurbValueContaining(String name);
+	public void setValue(String value) {
+		this.value = value;
+	}
 }

--- a/samples/data-jpa/src/main/java/app/main/model/Foo.java
+++ b/samples/data-jpa/src/main/java/app/main/model/Foo.java
@@ -1,15 +1,20 @@
 package app.main.model;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 @Entity
 public class Foo {
+
     @Id
     @GeneratedValue(strategy=GenerationType.AUTO)
     private long id;
 	private String value;
+	@OneToOne(cascade = CascadeType.ALL)
+	private Flurb flurb;
 	public Foo() {
 	}
 	public Foo(String value) {
@@ -27,4 +32,12 @@ public class Foo {
                 "Foo[id=%d, value='%s']",
                 id, value);
     }
+
+	public Flurb getFlurb() {
+		return flurb;
+	}
+
+	public void setFlurb(Flurb flurb) {
+		this.flurb = flurb;
+	}
 }

--- a/samples/data-jpa/src/test/java/app/main/SampleApplicationTests.java
+++ b/samples/data-jpa/src/test/java/app/main/SampleApplicationTests.java
@@ -17,14 +17,12 @@
 package app.main;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * @author Dave Syer
- *
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SampleApplicationTests {
@@ -34,7 +32,7 @@ public class SampleApplicationTests {
 
 	@Test
 	public void test() {
-		client.get().uri("/").exchange().expectBody(String.class).isEqualTo("{\"value\":\"Hello\"}");
+		client.get().uri("/").exchange().expectBody(String.class).isEqualTo("{\"value\":\"Hello\",\"flurb\":{}}");
 	}
 
 }

--- a/samples/data-jpa/verify.sh
+++ b/samples/data-jpa/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [[ ! `cat target/native-image/test-output.txt | grep -E "Application run failed|No suitable logging system located"` ]]; then
 RESPONSE=`curl -s localhost:8080/`
-if [[ "$RESPONSE" == '{"value":"Hello"}' ]]; then
+if [[ "$RESPONSE" == '{"value":"Hello","flurb":{}}' ]]; then
   exit 0
 else
   exit 1

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
@@ -84,7 +84,7 @@ import java.util.EventListener;
 				@TypeHint(types = {
 						// petclinic
 						Repository.class,
-						PersistenceContext.class, MappedSuperclass.class, Column.class, ManyToOne.class, JoinColumn.class, Table.class, Transient.class
+						PersistenceContext.class, MappedSuperclass.class, Column.class, ManyToOne.class, OneToMany.class, OneToOne.class, JoinColumn.class, Table.class, Transient.class
 				}, access = AccessBits.CLASS | AccessBits.DECLARED_METHODS),
 				@TypeHint(types = {
 						SessionImpl.class,


### PR DESCRIPTION
The methods of the annotations `@OneToMany` and `@OneToOne` weren't available for reflection, leading to failures when query derivation tried to acces those to determine if a relationship is optional or not.

Closes #660.