### PR TITLE
Add initial set of configuration hints and sample for Spring Data REST

### DIFF
--- a/samples/data-rest/README.md
+++ b/samples/data-rest/README.md
@@ -1,0 +1,11 @@
+Spring Boot project with Spring Data REST.
+
+To build and run the native application packaged in a lightweight container:
+```
+mvn spring-boot:build-image
+docker-compose up
+```
+
+As an alternative, you can use `build.sh` (with a local GraalVM installation or combined with
+`run-dev-container.sh` at the root of `spring-native` project). See also the related issue
+[Take advantage of Paketo dev-oriented images](https://github.com/spring-projects-experimental/spring-native/issues/227).

--- a/samples/data-rest/build.sh
+++ b/samples/data-rest/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+RC=0
+
+${PWD%/*samples/*}/scripts/compileWithMaven.sh && ${PWD%/*samples/*}/scripts/test.sh || RC=$?
+
+exit $RC

--- a/samples/data-rest/mvnw
+++ b/samples/data-rest/mvnw
@@ -1,0 +1,310 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Maven2 Start Up Batch script
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   M2_HOME - location of maven2's installed home dir
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        export JAVA_HOME="`/usr/libexec/java_home`"
+      else
+        export JAVA_HOME="/Library/Java/Home"
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+if [ -z "$M2_HOME" ] ; then
+  ## resolve links - $0 may be a link to maven's home
+  PRG="$0"
+
+  # need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG="`dirname "$PRG"`/$link"
+    fi
+  done
+
+  saveddir=`pwd`
+
+  M2_HOME=`dirname "$PRG"`/..
+
+  # make it fully qualified
+  M2_HOME=`cd "$M2_HOME" && pwd`
+
+  cd "$saveddir"
+  # echo Using m2 at $M2_HOME
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --unix "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME="`(cd "$M2_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="`which javac`"
+  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=`which readlink`
+    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
+      if $darwin ; then
+        javaHome="`dirname \"$javaExecutable\"`"
+        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
+      else
+        javaExecutable="`readlink -f \"$javaExecutable\"`"
+      fi
+      javaHome="`dirname \"$javaExecutable\"`"
+      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="`which java`"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=`cd "$wdir/.."; pwd`
+    fi
+    # end of workaround
+  done
+  echo "${basedir}"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    echo "$(tr -s '\n' ' ' < "$1")"
+  fi
+}
+
+BASE_DIR=`find_maven_basedir "$(pwd)"`
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+if [ -r "$BASE_DIR/.mvn/wrapper/maven-wrapper.jar" ]; then
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Found .mvn/wrapper/maven-wrapper.jar"
+    fi
+else
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
+    fi
+    if [ -n "$MVNW_REPOURL" ]; then
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+    else
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+    fi
+    while IFS="=" read key value; do
+      case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
+      esac
+    done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Downloading from: $jarUrl"
+    fi
+    wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+    if $cygwin; then
+      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
+    fi
+
+    if command -v wget > /dev/null; then
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Found wget ... using wget"
+        fi
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget "$jarUrl" -O "$wrapperJarPath"
+        else
+            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Found curl ... using curl"
+        fi
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl -o "$wrapperJarPath" "$jarUrl" -f
+        else
+            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+        fi
+        
+    else
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Falling back to using Java to download"
+        fi
+        javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaClass=`cygpath --path --windows "$javaClass"`
+        fi
+        if [ -e "$javaClass" ]; then
+            if [ ! -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
+                if [ "$MVNW_VERBOSE" = true ]; then
+                  echo " - Compiling MavenWrapperDownloader.java ..."
+                fi
+                # Compiling the Java class
+                ("$JAVA_HOME/bin/javac" "$javaClass")
+            fi
+            if [ -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
+                # Running the downloader
+                if [ "$MVNW_VERBOSE" = true ]; then
+                  echo " - Running MavenWrapperDownloader.java ..."
+                fi
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$MAVEN_PROJECTBASEDIR")
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+if [ "$MVNW_VERBOSE" = true ]; then
+  echo $MAVEN_PROJECTBASEDIR
+fi
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --path --windows "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/samples/data-rest/mvnw.cmd
+++ b/samples/data-rest/mvnw.cmd
@@ -1,0 +1,182 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Maven2 Start Up Batch script
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM M2_HOME - location of maven2's installed home dir
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%HOME%\mavenrc_pre.bat" call "%HOME%\mavenrc_pre.bat"
+if exist "%HOME%\mavenrc_pre.cmd" call "%HOME%\mavenrc_pre.cmd"
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+
+FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %DOWNLOAD_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%HOME%\mavenrc_post.bat" call "%HOME%\mavenrc_post.bat"
+if exist "%HOME%\mavenrc_post.cmd" call "%HOME%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%" == "on" pause
+
+if "%MAVEN_TERMINATE_CMD%" == "on" exit %ERROR_CODE%
+
+exit /B %ERROR_CODE%

--- a/samples/data-rest/pom.xml
+++ b/samples/data-rest/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.experimental</groupId>
+		<artifactId>spring-native-sample-parent</artifactId>
+		<version>0.9.2-SNAPSHOT</version>
+		<relativePath>../maven-parent/pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.springframework.samples</groupId>
+	<artifactId>data-rest</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<properties>
+		<java.version>1.8</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<main.class>com.example.data.rest.Application</main.class>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.experimental</groupId>
+			<artifactId>spring-native</artifactId>
+		</dependency>
+
+		<!-- Spring and Spring Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-rest</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<!-- Dependency added to check https://github.com/spring-projects-experimental/spring-native/issues/372 -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>2.5.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+			<version>2.5.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-rest-core</artifactId>
+			<version>3.5.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-rest-webmvc</artifactId>
+			<version>3.5.0-SNAPSHOT</version>
+		</dependency>
+
+
+		<!-- H2  -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<!-- Check out the parent POM for the plugins configuration -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.experimental</groupId>
+				<artifactId>spring-aot-maven-plugin</artifactId>
+				<configuration>
+					<removeSpelSupport>true</removeSpelSupport>
+					<removeYamlSupport>true</removeYamlSupport>
+					<removeXmlSupport>false</removeXmlSupport>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/samples/data-rest/pom.xml
+++ b/samples/data-rest/pom.xml
@@ -69,6 +69,11 @@
 			<artifactId>spring-data-rest-webmvc</artifactId>
 			<version>3.5.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.hateoas</groupId>
+			<artifactId>spring-hateoas</artifactId>
+			<version>1.3.0-SNAPSHOT</version>
+		</dependency>
 
 
 		<!-- H2  -->

--- a/samples/data-rest/src/main/java/com/example/data/rest/Address.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/Address.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * @author Oliver Gierke
+ */
+@Entity
+public class Address {
+
+	@GeneratedValue @Id//
+	private Long id;
+	private String street, zipCode, city, state;
+
+	Address() {
+
+		this.street = null;
+		this.zipCode = null;
+		this.city = null;
+		this.state = null;
+	}
+
+	public Address(String street, String zipCode, String city, String state) {
+
+		this.street = street;
+		this.zipCode = zipCode;
+		this.city = city;
+		this.state = state;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getStreet() {
+		return street;
+	}
+
+	public String getZipCode() {
+		return zipCode;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public void setZipCode(String zipCode) {
+		this.zipCode = zipCode;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	public String toString() {
+		return String.format("%s, %s %s, %s", street, zipCode, city, state);
+	}
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/Application.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/Application.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import javax.annotation.PostConstruct;
+import java.math.BigDecimal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Oliver Gierke
+ */
+@SpringBootApplication
+public class Application {
+
+	@Autowired CustomerRepository customers;
+	@Autowired OrderRepository orders;
+
+	public static void main(String... args) {
+		SpringApplication.run(Application.class, args);
+	}
+
+	public @PostConstruct
+	void init() {
+
+		Customer dave = customers.save(new Customer("Dave", "Matthews", new Address("4711 Some Place", "54321", "Charlottesville", "VA")));
+
+		Order order = new Order();
+
+		order.setCustomer(dave);
+		order.add(new LineItem("Lakewood guitar", new BigDecimal(1299.0)));
+
+		orders.save(order);
+	}
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/Customer.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/Customer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+/**
+ * @author Oliver Gierke
+ */
+@Entity
+public class Customer {
+
+	private @GeneratedValue @Id Long id;
+	private String firstname, lastname;
+
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)//
+	private Address address;
+
+	Customer() {
+		this.firstname = null;
+		this.lastname = null;
+		this.address = null;
+	}
+
+	public Customer(String firstname, String lastname, Address address) {
+		this.firstname = firstname;
+		this.lastname = lastname;
+		this.address = address;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getFirstname() {
+		return firstname;
+	}
+
+	public String getLastname() {
+		return lastname;
+	}
+
+	public void setFirstname(String firstname) {
+		this.firstname = firstname;
+	}
+
+	public void setLastname(String lastname) {
+		this.lastname = lastname;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/CustomerExcerpt.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/CustomerExcerpt.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.rest.core.config.Projection;
+
+/**
+ * @author Oliver Gierke
+ */
+@Projection(name = "excerpt", types = Customer.class)
+public interface CustomerExcerpt {
+
+	String getFirstname();
+
+	String getLastname();
+
+	@Value("#{target.address.toString()}")
+	String getAddress();
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/CustomerRepository.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/CustomerRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+/**
+ * @author Oliver Gierke
+ */
+@RepositoryRestResource(excerptProjection = CustomerExcerpt.class)
+public interface CustomerRepository extends CrudRepository<Customer, Long> {
+
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/CustomerRepository.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/CustomerRepository.java
@@ -15,7 +15,10 @@
  */
 package com.example.data.rest;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 /**
@@ -24,4 +27,5 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource(excerptProjection = CustomerExcerpt.class)
 public interface CustomerRepository extends CrudRepository<Customer, Long> {
 
+	List<Customer> findByLastname(@Param("lastname") String lastname);
 }

--- a/samples/data-rest/src/main/java/com/example/data/rest/LineItem.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/LineItem.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.math.BigDecimal;
+
+import org.springframework.util.ObjectUtils;
+
+/**
+ * @author Oliver Gierke
+ */
+@Entity
+public class LineItem {
+
+	private @GeneratedValue @Id Long id;
+	private final String description;
+	private final BigDecimal price;
+
+	LineItem() {
+		this.description = null;
+		this.price = null;
+	}
+
+	public LineItem(String description, BigDecimal price) {
+
+		this.description = description;
+		this.price = price;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public BigDecimal getPrice() {
+		return price;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		LineItem lineItem = (LineItem) o;
+
+		return ObjectUtils.nullSafeEquals(id, lineItem.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return ObjectUtils.nullSafeHashCode(id);
+	}
+
+	@Override
+	public String toString() {
+		return "LineItem{" +
+				"id=" + id +
+				", description='" + description + '\'' +
+				", price=" + price +
+				'}';
+	}
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/Order.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/Order.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Oliver Gierke
+ */
+@Entity(name = "SampleOrder")
+public class Order {
+
+	@Id @GeneratedValue//
+	private Long id;
+
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)//
+	private List<LineItem> items = new ArrayList<>();
+
+	@ManyToOne//
+	private Customer customer;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public List<LineItem> getItems() {
+		return items;
+	}
+
+	public void setItems(List<LineItem> items) {
+		this.items = items;
+	}
+
+	public Customer getCustomer() {
+		return customer;
+	}
+
+	public void setCustomer(Customer customer) {
+		this.customer = customer;
+	}
+
+	public Order add(LineItem item) {
+
+		this.items.add(item);
+		return this;
+	}
+}

--- a/samples/data-rest/src/main/java/com/example/data/rest/OrderRepository.java
+++ b/samples/data-rest/src/main/java/com/example/data/rest/OrderRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.rest;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Oliver Gierke
+ */
+public interface OrderRepository extends CrudRepository<Order, Long> {
+
+}

--- a/samples/data-rest/src/main/resources/application.properties
+++ b/samples/data-rest/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.data.rest.basePath=/api
+server.port=8080
+
+logging.level.org.springframework.data=trace
+logging.level.org.springframework.web.servlet.handler=trace

--- a/samples/data-rest/src/main/resources/application.properties
+++ b/samples/data-rest/src/main/resources/application.properties
@@ -2,4 +2,4 @@ spring.data.rest.basePath=/api
 server.port=8080
 
 logging.level.org.springframework.data=trace
-logging.level.org.springframework.web.servlet.handler=trace
+logging.level.org.springframework.web=trace

--- a/samples/data-rest/src/main/resources/hibernate.properties
+++ b/samples/data-rest/src/main/resources/hibernate.properties
@@ -1,0 +1,1 @@
+hibernate.bytecode.provider=none

--- a/samples/data-rest/verify.sh
+++ b/samples/data-rest/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+RESPONSE=`curl -s localhost:8080/api/customers/1`
+if [[ "$RESPONSE" == *"Matthews"* ]]; then
+  exit 0
+else
+  exit 1
+fi
+

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/reflect/ClassDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/reflect/ClassDescriptor.java
@@ -225,6 +225,9 @@ public final class ClassDescriptor implements Comparable<ClassDescriptor> {
 					if (fd.isAllowWrite()) {
 						existingSimilarOne.setAllowWrite(true);
 					}
+					if(fd.isAllowUnsafeAccess()) {
+						existingSimilarOne.setAllowUnsafeAccess(true);
+					}
 				} else {
 					addFieldDescriptor(fd);
 				}

--- a/spring-aot/src/main/java/org/springframework/nativex/support/ResourcesHandler.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/ResourcesHandler.java
@@ -1848,7 +1848,8 @@ public class ResourcesHandler extends Handler {
 			}
 //			logger.debug(spaces(depth) + "fixed flags? "+Flag.toString(flags));
 //			logger.debug(depth, "ms: "+methods);
-			reflectionHandler.addAccess(dname, MethodDescriptor.toStringArray(methods), null, true, flags);
+
+			reflectionHandler.addAccess(dname, MethodDescriptor.toStringArray(methods), FieldDescriptor.toStringArray(accessRequestor.getFieldAccessRequestedFor(dname)), true, flags);
 			/*
 			if (flags != null && flags.length == 1 && flags[0] == Flag.allDeclaredConstructors) {
 				Type resolvedType = ts.resolveDotted(dname, true);

--- a/spring-aot/src/main/java/org/springframework/nativex/type/FieldDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/FieldDescriptor.java
@@ -22,10 +22,12 @@ public class FieldDescriptor {
 	
 	private final String name;
 	private final boolean allowUnsafeAccess;
+	private final boolean allowWrite;
 	
-	public FieldDescriptor(String name, boolean allowUnsafeAccess) {
+	public FieldDescriptor(String name, boolean allowUnsafeAccess, boolean allowWrite) {
 		this.name = name;
 		this.allowUnsafeAccess = allowUnsafeAccess;
+		this.allowWrite = allowWrite;
 	}
 
 	public String getName() {
@@ -34,6 +36,10 @@ public class FieldDescriptor {
 
 	public boolean isAllowUnsafeAccess() {
 		return allowUnsafeAccess;
+	}
+
+	public boolean isAllowWrite() {
+		return allowWrite;
 	}
 
 	public static String[][] toStringArray(List<FieldDescriptor> fds) {
@@ -46,15 +52,23 @@ public class FieldDescriptor {
 			boolean aua = fd.allowUnsafeAccess;
 			String name = fd.getName();
 			if (aua) {
-				array[m] = new String[2];
+				array[m] = new String[fd.allowWrite ? 3 : 2];
 				array[m][0] = name;
 				array[m][1] = "true";
+				if(fd.allowWrite) {
+					array[m][2] = "true";
+				}
 			} else {
-				array[m] = new String[1];
+				array[m] = new String[fd.allowWrite ? 3 : 1];
 				array[m][0] = name;
+				if(fd.allowWrite) {
+					array[m][1] = "false";
+					array[m][2] = "true";
+				}
 			}
 		}
 		return array;
 	}
+
 
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
@@ -1870,16 +1870,20 @@ public class Type {
 		List<Object> values = fieldInfo.values;
 		String name = null;
 		boolean allowUnsafeAccess = false; // default is false
+		boolean allowWrite = false; // default is false
 		for (int i = 0; i < values.size(); i += 2) {
 			String key = (String) values.get(i);
 			Object value = values.get(i + 1);
 			if (key.equals("allowUnsafeAccess")) {
 				allowUnsafeAccess = (Boolean) value;
-			} else if (key.equals("name")) {
+			} else if (key.equals("allowWrite")) {
+				allowWrite = (Boolean) value;
+			}
+			else if (key.equals("name")) {
 				name = (String) value;
 			}
 		}
-		fds.add(new FieldDescriptor(name, allowUnsafeAccess));
+		fds.add(new FieldDescriptor(name, allowUnsafeAccess, allowWrite));
 	}
 
 	private void unpackMethodInfo(AnnotationNode methodInfo, List<MethodDescriptor> mds) {

--- a/spring-native-configuration/pom.xml
+++ b/spring-native-configuration/pom.xml
@@ -68,6 +68,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-rest-webmvc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>provided</scope>

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonHints.java
@@ -16,12 +16,15 @@
 
 package org.springframework.boot.autoconfigure.jackson;
 
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ext.Java7Handlers;
 import com.fasterxml.jackson.databind.ext.Java7HandlersImpl;
 import com.fasterxml.jackson.databind.ext.Java7Support;
 import com.fasterxml.jackson.databind.ext.Java7SupportImpl;
 import com.fasterxml.jackson.databind.util.ClassUtil;
-
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.InitializationHint;
 import org.springframework.nativex.hint.InitializationTime;
@@ -29,13 +32,19 @@ import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
-
 @NativeHint(trigger = JacksonAutoConfiguration.class, types = {
-		@TypeHint(types = {JsonIgnore.class, JsonInclude.class,JsonInclude.Include.class}, access = AccessBits.CLASS | AccessBits.DECLARED_METHODS),
-		@TypeHint(types = JsonGenerator.class, access = AccessBits.LOAD_AND_CONSTRUCT | AccessBits.PUBLIC_METHODS) },
+		@TypeHint(types = {
+				JsonPropertyOrder.class,
+				JsonDeserialize.class, JsonProperty.class,
+				JsonGetter.class, JsonSetter.class,
+				JsonValue.class, JsonView.class,
+				JsonTypeInfo.class, JsonIgnoreProperties.class,
+				JsonAnyGetter.class, JsonAnySetter.class,
+				JsonSerialize.class, JsonUnwrapped.class,
+				JsonIgnore.class, JsonInclude.class,
+				JsonInclude.Include.class}, access = AccessBits.ANNOTATION),
+		@TypeHint(types = JsonGenerator.class, access = AccessBits.LOAD_AND_CONSTRUCT | AccessBits.PUBLIC_METHODS)},
 		initialization = @InitializationHint(types = {Java7Handlers.class, Java7HandlersImpl.class, Java7Support.class, Java7SupportImpl.class, ClassUtil.class}, initTime = InitializationTime.BUILD))
 public class JacksonHints implements NativeConfiguration {
+
 }

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonHints.java
@@ -34,7 +34,7 @@ import org.springframework.nativex.type.NativeConfiguration;
 
 @NativeHint(trigger = JacksonAutoConfiguration.class, types = {
 		@TypeHint(types = {
-				JsonPropertyOrder.class,
+				JsonPropertyOrder.class, JsonCreator.class,
 				JsonDeserialize.class, JsonProperty.class,
 				JsonGetter.class, JsonSetter.class,
 				JsonValue.class, JsonView.class,

--- a/spring-native-configuration/src/main/java/org/springframework/data/SpringDataCommonsHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/SpringDataCommonsHints.java
@@ -50,7 +50,10 @@ import org.springframework.nativex.hint.AccessBits;
 						PropertiesBasedNamedQueries.class
 				}),
 				@TypeHint(types = {Properties.class, BeanFactory.class, InputStreamSource[].class}, access = AccessBits.CLASS),
-				@TypeHint(types = Throwable.class, access = AccessBits.LOAD_AND_CONSTRUCT | AccessBits.DECLARED_FIELDS)
+				@TypeHint(types = Throwable.class, access = AccessBits.LOAD_AND_CONSTRUCT | AccessBits.DECLARED_FIELDS),
+				@TypeHint(typeNames = {
+						"org.springframework.data.projection.SpelEvaluatingMethodInterceptor$TargetWrapper",
+				}, access = AccessBits.ALL)
 		},
 		proxies = @ProxyHint(typeNames = {
 				"org.springframework.data.annotation.QueryAnnotation",

--- a/spring-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
@@ -398,13 +398,22 @@ public class SpringDataComponentProcessor implements ComponentProcessor {
 		for (Type annotation : method.getAnnotationTypes()) {
 			registerSpringDataAnnotation(annotation, context);
 		}
+
+		if(method.getParameterCount() == 0) {
+			return;
+		}
+
+		// lookup for parameter annotations like @Param
+		for(int i=0; i<method.getParameterCount();i++) {
+			method.getParameterAnnotationTypes(i).forEach(it -> registerSpringDataAnnotation(it, context));
+		}
 	}
 
 	private void registerSpringDataAnnotation(Type annotation, NativeContext context) {
 
 		if (!context.hasReflectionConfigFor(annotation) && isPartOfSpringData(annotation)) {
 
-			context.addReflectiveAccess(annotation.getDottedName(), Flag.allPublicMethods);
+			context.addReflectiveAccess(annotation.getDottedName(), AccessBits.ANNOTATION);
 			context.addProxy(annotation.getDottedName(), "org.springframework.core.annotation.SynthesizedAnnotation");
 
 			log.annotationFound(annotation);

--- a/spring-native-configuration/src/main/java/org/springframework/data/rest/webmvc/config/RestControllerHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/rest/webmvc/config/RestControllerHints.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.rest.webmvc.config;
+
+import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.TypeHint;
+import org.springframework.nativex.type.NativeConfiguration;
+
+@NativeHint(trigger = org.springframework.data.rest.webmvc.config.RestControllerImportSelector.class, types = {
+		@TypeHint(typeNames = {
+				"org.springframework.data.rest.webmvc.RestControllerConfiguration",
+				"org.springframework.data.rest.webmvc.halexplorer.HalExplorerConfiguration"
+		})
+})
+public class RestControllerHints implements NativeConfiguration {
+
+}

--- a/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
@@ -16,12 +16,10 @@
 package org.springframework.data.web.config;
 
 import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
-import org.springframework.boot.autoconfigure.hateoas.HypermediaHttpMessageConverterConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcHints;
 import org.springframework.hateoas.config.HateoasHints;
 import org.springframework.hateoas.mediatype.hal.HalMediaTypeConfiguration;
 import org.springframework.nativex.hint.AccessBits;
-import org.springframework.nativex.hint.FieldHint;
 import org.springframework.nativex.hint.InitializationHint;
 import org.springframework.nativex.hint.InitializationTime;
 import org.springframework.nativex.hint.NativeHint;
@@ -32,6 +30,7 @@ import reactor.core.publisher.Flux;
 
 @NativeHint(trigger = RepositoryRestMvcAutoConfiguration.class, types = {
 		@TypeHint(types = {
+
 				Flux.class,
 				org.reactivestreams.Publisher.class,
 				HalMediaTypeConfiguration.class,
@@ -44,11 +43,15 @@ import reactor.core.publisher.Flux;
 		},
 				typeNames = {
 
-						"org.springframework.hateoas.EntityModel",
+//						"org.springframework.hateoas.EntityModel",
 //						"org.springframework.hateoas.CollectionModel",
-						"org.springframework.hateoas.AffordanceModel",
-						"org.springframework.hateoas.config.RestTemplateHateoasConfiguration",
-						"org.springframework.hateoas.mediatype.hal.forms.HalFormsMediaTypeConfiguration",
+//						"org.springframework.hateoas.AffordanceModel",
+//						"org.springframework.hateoas.config.RestTemplateHateoasConfiguration",
+//						"org.springframework.hateoas.mediatype.hal.forms.HalFormsMediaTypeConfiguration",
+
+						"org.springframework.data.rest.core.annotation.Description",
+						"org.springframework.data.rest.core.config.EnumTranslationConfiguration",
+						"org.springframework.data.rest.core.config.RepositoryRestConfiguration",
 
 						"org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration",
 						"org.springframework.data.rest.webmvc.RepositoryRestController",
@@ -61,13 +64,10 @@ import reactor.core.publisher.Flux;
 						"org.springframework.data.rest.webmvc.RepositoryController",
 						"org.springframework.data.rest.webmvc.RepositoryPropertyReferenceController",
 						"org.springframework.data.rest.webmvc.RepositorySearchController",
-
-						"org.springframework.data.rest.core.annotation.Description",
-
-						"org.springframework.data.rest.core.config.RepositoryRestConfiguration",
-
-						"org.springframework.boot.autoconfigure.data.rest.SpringBootRepositoryRestConfigurer",
 						"org.springframework.data.rest.webmvc.config.WebMvcRepositoryRestConfiguration",
+
+						// BOOT CONFIG
+						"org.springframework.boot.autoconfigure.data.rest.SpringBootRepositoryRestConfigurer",
 
 						// PLUGIN
 						"org.springframework.plugin.core.support.PluginRegistryFactoryBean",
@@ -81,10 +81,8 @@ import reactor.core.publisher.Flux;
 						"org.springframework.plugin.core.support.AbstractTypeAwareSupport",
 						"org.springframework.plugin.core.support.PluginRegistryFactoryBean",
 
-						"org.springframework.data.rest.core.config.EnumTranslationConfiguration",
-
 						// JACKSON
-						"org.springframework.hateoas.EntityModel$MapSuppressingUnwrappingSerializer",
+//						"org.springframework.hateoas.EntityModel$MapSuppressingUnwrappingSerializer",
 
 						// EvoInflector
 						"org.atteo.evo.inflector.English"
@@ -93,12 +91,6 @@ import reactor.core.publisher.Flux;
 				access = AccessBits.ALL
 
 		),
-		@TypeHint(
-
-				typeNames = "org.springframework.hateoas.CollectionModel",
-				fields = @FieldHint(name = "content", allowUnsafeAccess = true, allowWrite = true) // TODO: can we please solve this in Data REST
-//				access = AccessBits.L
-		)
 },
 		proxies = {
 				@ProxyHint(typeNames = {"org.springframework.data.rest.webmvc.BasePathAwareController", "org.springframework.core.annotation.SynthesizedAnnotation"}),

--- a/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web.config;
+
+import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcHints;
+import org.springframework.hateoas.mediatype.hal.HalMediaTypeConfiguration;
+import org.springframework.nativex.hint.AccessBits;
+import org.springframework.nativex.hint.InitializationHint;
+import org.springframework.nativex.hint.InitializationTime;
+import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.ProxyHint;
+import org.springframework.nativex.hint.TypeHint;
+import org.springframework.nativex.type.NativeConfiguration;
+import reactor.core.publisher.Flux;
+
+@NativeHint(trigger = RepositoryRestMvcAutoConfiguration.class, types = {
+		@TypeHint(types = {
+				Flux.class,
+				org.reactivestreams.Publisher.class,
+				HalMediaTypeConfiguration.class,
+
+				org.springframework.stereotype.Controller.class,
+				org.springframework.data.repository.core.support.RepositoryFactoryInformation.class,
+				org.springframework.data.repository.support.Repositories.class,
+				org.springframework.data.repository.support.RepositoryInvoker.class,
+				org.springframework.data.repository.support.RepositoryInvokerFactory.class,
+		},
+				typeNames = {
+
+						"org.springframework.hateoas.EntityModel",
+						"org.springframework.hateoas.CollectionModel",
+						"org.springframework.hateoas.AffordanceModel",
+						"org.springframework.hateoas.config.RestTemplateHateoasConfiguration",
+						"org.springframework.hateoas.mediatype.hal.forms.HalFormsMediaTypeConfiguration",
+
+						"org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration",
+						"org.springframework.data.rest.webmvc.RepositoryRestController",
+						"org.springframework.data.rest.webmvc.BasePathAwareController",
+
+						"org.springframework.data.rest.webmvc.RepositorySchemaController",
+						"org.springframework.data.rest.webmvc.ProfileController",
+						"org.springframework.data.rest.webmvc.alps.AlpsController",
+						"org.springframework.data.rest.webmvc.RepositoryEntityController",
+						"org.springframework.data.rest.webmvc.RepositoryController",
+						"org.springframework.data.rest.webmvc.RepositoryPropertyReferenceController",
+						"org.springframework.data.rest.webmvc.RepositorySearchController",
+
+						"org.springframework.data.rest.core.annotation.Description",
+
+						"org.springframework.data.rest.core.config.RepositoryRestConfiguration",
+
+						"org.springframework.boot.autoconfigure.data.rest.SpringBootRepositoryRestConfigurer",
+						"org.springframework.data.rest.webmvc.config.WebMvcRepositoryRestConfiguration",
+
+						// PLUGIN
+						"org.springframework.plugin.core.support.PluginRegistryFactoryBean",
+						"org.springframework.plugin.core.OrderAwarePluginRegistry",
+						"org.springframework.plugin.core.Plugin",
+						"org.springframework.plugin.core.PluginRegistry",
+						"org.springframework.plugin.core.PluginRegistrySupport",
+						"org.springframework.plugin.core.SimplePluginRegistry",
+						"org.springframework.plugin.core.config.EnablePluginRegistries",
+						"org.springframework.plugin.core.config.PluginRegistriesBeanDefinitionRegistrar",
+						"org.springframework.plugin.core.support.AbstractTypeAwareSupport",
+						"org.springframework.plugin.core.support.PluginRegistryFactoryBean",
+
+						"org.springframework.data.rest.core.config.EnumTranslationConfiguration",
+
+						// JACKSON
+						"org.springframework.hateoas.EntityModel$MapSuppressingUnwrappingSerializer",
+
+						// EvoInflector
+						"org.atteo.evo.inflector.English"
+				},
+				access = AccessBits.ALL
+
+		)
+},
+		proxies = {
+				@ProxyHint(typeNames = {"org.springframework.data.rest.webmvc.BasePathAwareController", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.data.rest.webmvc.RepositoryRestController", "org.springframework.data.rest.webmvc.BasePathAwareController", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"java.util.List", "org.springframework.aop.SpringProxy", "org.springframework.aop.framework.Advised", "org.springframework.core.DecoratingProxy"}),
+				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestParam", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestBody", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.PathVariable", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.ModelAttribute", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.stereotype.Controller", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.ControllerAdvice", "org.springframework.core.annotation.SynthesizedAnnotation"}),
+				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestHeader", "org.springframework.core.annotation.SynthesizedAnnotation"})
+		},
+		initialization = {
+				@InitializationHint(types = {org.springframework.hateoas.MediaTypes.class, org.springframework.util.MimeTypeUtils.class}, initTime = InitializationTime.BUILD)
+		},
+		imports = {
+				WebMvcHints.class
+		}
+
+)
+public class DataRestHints implements NativeConfiguration {
+
+	// TODO: add a component processor that resolves types implementing RepositoryRestConfigurer
+
+	// TODO: split up and refine access to hateos and plugin configuration classes
+
+	// TODO: inspect RepositoryRestResource for excerpt projections and register proxy
+	//  <excerpt projection interface name>, org.springframework.data.projection.TargetAware, org.springframework.aop.SpringProxy, org.springframework.core.DecoratingProxy
+}

--- a/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
@@ -16,7 +16,9 @@
 package org.springframework.data.web.config;
 
 import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.hateoas.HypermediaHttpMessageConverterConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcHints;
+import org.springframework.hateoas.config.HateoasHints;
 import org.springframework.hateoas.mediatype.hal.HalMediaTypeConfiguration;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.FieldHint;
@@ -115,7 +117,7 @@ import reactor.core.publisher.Flux;
 				@InitializationHint(types = {org.springframework.hateoas.MediaTypes.class, org.springframework.util.MimeTypeUtils.class}, initTime = InitializationTime.BUILD)
 		},
 		imports = {
-				WebMvcHints.class
+				WebMvcHints.class, HateoasHints.class
 		}
 
 )

--- a/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
@@ -19,6 +19,7 @@ import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoCon
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcHints;
 import org.springframework.hateoas.mediatype.hal.HalMediaTypeConfiguration;
 import org.springframework.nativex.hint.AccessBits;
+import org.springframework.nativex.hint.FieldHint;
 import org.springframework.nativex.hint.InitializationHint;
 import org.springframework.nativex.hint.InitializationTime;
 import org.springframework.nativex.hint.NativeHint;
@@ -42,7 +43,7 @@ import reactor.core.publisher.Flux;
 				typeNames = {
 
 						"org.springframework.hateoas.EntityModel",
-						"org.springframework.hateoas.CollectionModel",
+//						"org.springframework.hateoas.CollectionModel",
 						"org.springframework.hateoas.AffordanceModel",
 						"org.springframework.hateoas.config.RestTemplateHateoasConfiguration",
 						"org.springframework.hateoas.mediatype.hal.forms.HalFormsMediaTypeConfiguration",
@@ -86,8 +87,15 @@ import reactor.core.publisher.Flux;
 						// EvoInflector
 						"org.atteo.evo.inflector.English"
 				},
+
 				access = AccessBits.ALL
 
+		),
+		@TypeHint(
+
+				typeNames = "org.springframework.hateoas.CollectionModel",
+				fields = @FieldHint(name = "content", allowUnsafeAccess = true, allowWrite = true) // TODO: can we please solve this in Data REST
+//				access = AccessBits.L
 		)
 },
 		proxies = {
@@ -102,6 +110,7 @@ import reactor.core.publisher.Flux;
 				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.ControllerAdvice", "org.springframework.core.annotation.SynthesizedAnnotation"}),
 				@ProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestHeader", "org.springframework.core.annotation.SynthesizedAnnotation"})
 		},
+
 		initialization = {
 				@InitializationHint(types = {org.springframework.hateoas.MediaTypes.class, org.springframework.util.MimeTypeUtils.class}, initTime = InitializationTime.BUILD)
 		},

--- a/spring-native-configuration/src/main/java/org/springframework/hateoas/config/HateoasHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/hateoas/config/HateoasHints.java
@@ -19,44 +19,93 @@ package org.springframework.hateoas.config;
 import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
 import org.springframework.boot.autoconfigure.hateoas.HypermediaHttpMessageConverterConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonHints;
+import org.springframework.hateoas.Affordance;
+import org.springframework.hateoas.AffordanceModel;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.server.core.Relation;
 import org.springframework.nativex.hint.AccessBits;
+import org.springframework.nativex.hint.FieldHint;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
 
 
-@NativeHint(trigger=WebStackImportSelector.class, types = {
-	@TypeHint(types= {
-			WebMvcHateoasConfiguration.class,
-			WebFluxHateoasConfiguration.class
-	})
+@NativeHint(trigger = WebStackImportSelector.class, types = {
+		@TypeHint(types = {
+				WebMvcHateoasConfiguration.class,
+				WebFluxHateoasConfiguration.class
+		})
 })
-@NativeHint(trigger=HypermediaConfigurationImportSelector.class, types =
-	@TypeHint(types= {
-			HypermediaConfigurationImportSelector.class,
-			EnableHypermediaSupport.class,
-			HypermediaType.class,
-			HypermediaType[].class,
-			MediaTypeConfigurationProvider.class
-	}))
+@NativeHint(trigger = HypermediaConfigurationImportSelector.class, types =
+@TypeHint(types = {
+		HypermediaConfigurationImportSelector.class,
+		EnableHypermediaSupport.class,
+		HypermediaType.class,
+		HypermediaType[].class,
+		MediaTypeConfigurationProvider.class
+}))
 @NativeHint(trigger = HypermediaAutoConfiguration.class,
 		types = {
 				@TypeHint(types = {
+
 						HypermediaConfigurationImportSelector.class,
 						HateoasConfiguration.class,
-						HypermediaHttpMessageConverterConfiguration.class
-					},
+						HypermediaHttpMessageConverterConfiguration.class,
+
+						Relation.class,
+
+						Link.class,
+						LinkRelation.class,
+						Affordance.class,
+						AffordanceModel.class,
+
+						EntityModel.class,
+						PagedModel.class,
+						RepresentationModel.class,
+
+						RestTemplateHateoasConfiguration.class,
+				},
 						typeNames = {
-							"org.springframework.hateoas.mediatype.hal.HalConfiguration",
-							"org.springframework.hateoas.mediatype.hal.Jackson2HalModule",
-							"org.springframework.hateoas.mediatype.hal.LinkMixin",
-							"org.springframework.hateoas.mediatype.hal.RepresentationModelMixin",
-							"org.springframework.hateoas.mediatype.hal.CollectionModelMixin"
+
+								"org.springframework.hateoas.StringLinkRelation",
+								"org.springframework.hateoas.EntityModel$MapSuppressingUnwrappingSerializer",
+
+								// HAL
+								"org.springframework.hateoas.mediatype.hal.HalConfiguration",
+								"org.springframework.hateoas.mediatype.hal.Jackson2HalModule",
+								"org.springframework.hateoas.mediatype.hal.LinkMixin",
+								"org.springframework.hateoas.mediatype.hal.RepresentationModelMixin",
+								"org.springframework.hateoas.mediatype.hal.CollectionModelMixin",
+								"org.springframework.hateoas.mediatype.hal.HalLinkRelation",
+								"org.springframework.hateoas.mediatype.hal.Jackson2HalModule$HalLink",
+								"org.springframework.hateoas.mediatype.hal.Jackson2HalModule$HalLinkListSerializer",
+								"org.springframework.hateoas.mediatype.hal.Jackson2HalModule$HalLinkListDeserializer",
+								"org.springframework.hateoas.mediatype.hal.Jackson2HalModule$TrueOnlyBooleanSerializer",
+								"org.springframework.hateoas.mediatype.hal.Jackson2HalModule$EmbeddedMapper",
+								"org.springframework.hateoas.mediatype.hal.forms.HalFormsMediaTypeConfiguration"
+
+								// TODO: ALPS
+
+								// TODO: COLLECTION JSON
+
+								// TODO: UBER
+
 						}, access = AccessBits.ALL
+				),
+				@TypeHint(
+						types = CollectionModel.class,
+						fields = @FieldHint(name = "content", allowUnsafeAccess = true, allowWrite = true)
 				)
+		},
+		imports = {
+				JacksonHints.class
 		}
-		, imports = {JacksonHints.class}
 )
 public class HateoasHints implements NativeConfiguration {
 

--- a/spring-native-configuration/src/main/java/org/springframework/hateoas/config/HateoasHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/hateoas/config/HateoasHints.java
@@ -16,7 +16,11 @@
 
 package org.springframework.hateoas.config;
 
+import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
+import org.springframework.boot.autoconfigure.hateoas.HypermediaHttpMessageConverterConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonHints;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
@@ -36,5 +40,24 @@ import org.springframework.nativex.type.NativeConfiguration;
 			HypermediaType[].class,
 			MediaTypeConfigurationProvider.class
 	}))
+@NativeHint(trigger = HypermediaAutoConfiguration.class,
+		types = {
+				@TypeHint(types = {
+						HypermediaConfigurationImportSelector.class,
+						HateoasConfiguration.class,
+						HypermediaHttpMessageConverterConfiguration.class
+					},
+						typeNames = {
+							"org.springframework.hateoas.mediatype.hal.HalConfiguration",
+							"org.springframework.hateoas.mediatype.hal.Jackson2HalModule",
+							"org.springframework.hateoas.mediatype.hal.LinkMixin",
+							"org.springframework.hateoas.mediatype.hal.RepresentationModelMixin",
+							"org.springframework.hateoas.mediatype.hal.CollectionModelMixin"
+						}, access = AccessBits.ALL
+				)
+		}
+		, imports = {JacksonHints.class}
+)
 public class HateoasHints implements NativeConfiguration {
+
 }

--- a/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.NativeConfiguration
+++ b/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.NativeConfiguration
@@ -87,6 +87,8 @@ org.springframework.cloud.netflix.eureka.EurekaClientHints
 org.springframework.cloud.sleuth.TraceHints
 org.springframework.context.annotation.ContextAnnotationHints
 org.springframework.core.annotation.CoreAnnotationHints
+org.springframework.data.rest.webmvc.config.RestControllerHints
+org.springframework.data.web.config.DataRestHints
 org.springframework.data.web.config.SpringDataWebHints
 org.springframework.hateoas.config.HateoasHints
 org.springframework.kafka.annotation.KafkaHints

--- a/spring-native/src/main/java/org/springframework/nativex/hint/FieldHint.java
+++ b/spring-native/src/main/java/org/springframework/nativex/hint/FieldHint.java
@@ -25,6 +25,7 @@ import java.lang.annotation.RetentionPolicy;
  * @see <a href="https://www.graalvm.org/reference-manual/native-image/Reflection/#manual-configuration">Manual configuration of reflection use in native images</a>
  * @author Andy Clement
  * @author Sebastien Deleuze
+ * @author Christoph Strobl
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface FieldHint {
@@ -41,7 +42,12 @@ public @interface FieldHint {
 	 * @see <a href="https://www.graalvm.org/reference-manual/native-image/Reflection/#unsafe-accesses">Unsafe accesses</a>
 	 */
 	boolean allowUnsafeAccess() default false;
-	
-	// TODO support allowWrite option when a use case requires it
+
+	/**
+	 * Allow write access on the related field.
+	 * @return {@code true} if allowed.
+	 * @see <a href="https://www.graalvm.org/reference-manual/native-image/Reflection/#manual-configuration">Manual Configuration</a>
+	 */
+	boolean allowWrite() default false;
 
 }


### PR DESCRIPTION
This PR adds the initial set of required hints to run a sample application using Spring Data REST and the HAL representation model.

```bash
http :8080/api/customers/1

{
    "_links": {
        "customer": {
            "href": "http://localhost:8080/api/customers/1{?projection}",
            "templated": true
        },
        "self": {
            "href": "http://localhost:8080/api/customers/1"
        }
    },
    "address": {
        "city": "Charlottesville",
        "state": "VA",
        "street": "4711 Some Place",
        "zipCode": "54321"
    },
    "firstname": "Dave",
    "lastname": "Matthews"
}
```
Along with Data REST specific hints the `allowWrite` attribute has been added to the `FieldHint` annotation (via ffdca18)

So far it is possible to expose the collection and entity endpoints. The `search` endpoint and others (like `profile`), as well as support for other media types and ALPS will be added subsequently moving forward.  

We'll potentially require additional changes in Data REST (eg. to fully support the `search` endpoint as the parameter name for the `@PathVariable` is not resolved from the method parameter name) and will upgrade to a more recent version once the upcoming Spring Data RC is out.
