### PR TITLE
Hint for Kafka Consumer Proxies

### DIFF
--- a/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
+++ b/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @SpringBootApplication
@@ -28,7 +29,10 @@ public class KafkaApplication {
 	}
 
 	@Bean
-	public ApplicationRunner runner(KafkaTemplate<String, String> template) {
+	public ApplicationRunner runner(KafkaTemplate<String, String> template,
+				ConsumerFactory<String, String> cf) {
+
+		cf.addListener(new ConsumerFactory.Listener() { });
 		return args -> {
 			template.send("graal", "foo");
 			System.out.println("++++++Sent:foo");

--- a/spring-native-configuration/src/main/java/org/springframework/kafka/annotation/KafkaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/kafka/annotation/KafkaHints.java
@@ -17,6 +17,7 @@
 package org.springframework.kafka.annotation;
 
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
@@ -42,6 +43,7 @@ import org.springframework.kafka.support.ProducerListener;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.ProxyHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
 
@@ -96,7 +98,13 @@ import org.springframework.nativex.type.NativeConfiguration;
 				StringSerializer.class,
 				JsonSerializer.class
 			}, typeNames = "java.util.zip.CRC32C")
-	}
+	},
+	proxies = @ProxyHint(types = {
+			Consumer.class,
+			org.springframework.aop.SpringProxy.class,
+			org.springframework.aop.framework.Advised.class,
+			org.springframework.core.DecoratingProxy.class
+	})
 )
 public class KafkaHints implements NativeConfiguration {
 }


### PR DESCRIPTION
When the consumer factory has listeners attached (e.g. with actuator
and micrometer), consumers are proxied so that we can call the listener
when the consumer is closed.

Add hints to allow such proxies.