### PR TITLE
Fix reflective configuration for domain types discovered by Spring Data.

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/SpringDataComponentProcessor.java
@@ -389,13 +389,8 @@ public class SpringDataComponentProcessor implements ComponentProcessor {
 
 		log.message("Adding reflective access to " + type.getDottedName());
 
-		if (type.hasAnnotationInHierarchy("Lorg/springframework/data/annotation/AccessType;")) {
-			nativeContext.addReflectiveAccess(type.getDottedName(),
-					Flag.allDeclaredConstructors, Flag.allDeclaredMethods);
-		} else {
-			nativeContext.addReflectiveAccess(type.getDottedName(), Flag.allDeclaredConstructors, Flag.allDeclaredMethods,
-					Flag.allDeclaredFields);
-		}
+		nativeContext.addReflectiveAccess(type.getDottedName(), Flag.allDeclaredConstructors, Flag.allDeclaredMethods,
+				Flag.allDeclaredFields);
 	}
 
 	private void registerSpringDataAnnotationInConfiguration(Type annotation, NativeContext context) {


### PR DESCRIPTION
This commit makes sure field access is always possible (independent from the `@AccessType` declaration). This fixes the data-jdbc sample.