### PR TITLE
Refine Spring HATEOAS hints.

### DIFF
--- a/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
@@ -67,6 +67,8 @@ import org.springframework.nativex.hint.SerializationHints;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.hint.TypeHints;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Andy Clement
@@ -627,7 +629,34 @@ public class Type {
 				if (anno.desc.equals(lookingFor)) {
 					List<Object> os = anno.values;
 					for (int i = 0; i < os.size(); i += 2) {
-						collector.put(os.get(i).toString(), os.get(i + 1).toString());
+						if(os.get(i+1) instanceof List) {
+
+							List<String> resolvedAttributeValues = new ArrayList<>();
+
+							for(Object attributeValue : (List)os.get(i+1)) {
+
+								if(!ObjectUtils.isArray(attributeValue)) {
+									resolvedAttributeValues.add(attributeValue.toString());
+									continue;
+								}
+
+								String attributeValueStringRepresentation = "";
+								String[] args = (String[]) attributeValue;
+								if(args[0].startsWith("L") && args[0].endsWith(";")) {
+									Type resolve = typeSystem.Lresolve(args[0], true);
+									if(resolve != null) {
+										attributeValueStringRepresentation = resolve.getDottedName();
+									}
+								}
+								if(args.length > 1) {
+									attributeValueStringRepresentation += ("." + args[1]);
+								}
+								resolvedAttributeValues.add(attributeValueStringRepresentation);
+							}
+							collector.put(os.get(i).toString(), StringUtils.collectionToDelimitedString(resolvedAttributeValues, ";"));
+						} else {
+							collector.put(os.get(i).toString(), os.get(i + 1).toString());
+						}
 					}
 				}
 				try {

--- a/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
@@ -37,6 +37,7 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -1073,7 +1074,7 @@ public class Type {
 		return getJavaxAnnotations(new HashSet<>());
 	}
 
-	private boolean isAnnotated(String Ldescriptor) {
+	public boolean isAnnotated(String Ldescriptor) {
 		if (dimensions > 0) {
 			return false;
 		}

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
@@ -120,12 +120,15 @@ import java.util.EventListener;
 						EntityManagerMessageLogger.class, // CoreMessageLogger.class,
 						Session.class, EventListener.class,
 
-						EnumType.class
+						EnumType.class,
+						InheritanceType.class,
+
 				}, typeNames = {
 						"org.hibernate.internal.EntityManagerMessageLogger_$logger",
 						"org.hibernate.service.jta.platform.internal.NoJtaPlatform",
 						"org.hibernate.annotations.common.util.impl.Log_$logger",
 						"org.hibernate.annotations.common.util.impl.Log",
+						"org.hibernate.cfg.beanvalidation.TypeSafeActivator",
 				}),
 				@TypeHint(types = {org.hibernate.internal.CoreMessageLogger_$logger.class,
 						// These from EntityTuplizerFactory

--- a/spring-native-configuration/src/main/java/org/springframework/data/JpaComponentProcessor.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/JpaComponentProcessor.java
@@ -147,6 +147,8 @@ public class JpaComponentProcessor implements ComponentProcessor {
 		public void process(Type type, NativeContext context) {
 
 			if (type.isEnum() && !context.hasReflectionConfigFor(ENUM_TYPE)) {
+
+				context.log(String.format("JpaComponentProcessor: detected enum usage in entity. Adding load/construct for %s.", type, ENUM_TYPE));
 				context.addReflectiveAccess(ENUM_TYPE, new AccessDescriptor(AccessBits.LOAD_AND_CONSTRUCT));
 			}
 		}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/Drink.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/Drink.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+public class Drink {
+
+}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/DrinksModelProcessor.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/DrinksModelProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+
+public class DrinksModelProcessor implements RepresentationModelProcessor<CollectionModel<EntityModel<Drink>>> {
+
+	@Override
+	public CollectionModel<EntityModel<Drink>> process(CollectionModel<EntityModel<Drink>> model) {
+		return model;
+	}
+}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/Person.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/Person.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+public class Person {
+
+}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/PersonRepresentationModel.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/PersonRepresentationModel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.RepresentationModel;
+
+public class PersonRepresentationModel extends RepresentationModel<EntityModel<Person>> {
+
+}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/TypeUsingJackson.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/TypeUsingJackson.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+
+@JsonClassDescription("this-type-uses-jackson-srly-no-kidding")
+public class TypeUsingJackson {
+
+	Object name;
+}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/TypeUsingJacksonOnField.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/TypeUsingJacksonOnField.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+public class TypeUsingJacksonOnField {
+
+	@JsonAlias({ "n", "Name" })
+	Object name;
+}

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/TypeUsingJacksonOnMethod.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/TypeUsingJacksonOnMethod.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.test.hateoas;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TypeUsingJacksonOnMethod {
+
+	@JsonProperty("name")
+	Object getName() {
+		return "name";
+	}
+}

--- a/spring-native-configuration/src/test/java/org/springframework/hateoas/config/HateoasHintsTests.java
+++ b/spring-native-configuration/src/test/java/org/springframework/hateoas/config/HateoasHintsTests.java
@@ -67,7 +67,7 @@ public class HateoasHintsTests {
 	@Test
 	public void jackson() {
 
-		List<HintDeclaration> hintDeclarations = hateoasHints.computeJacksonMappings(typeSystem);
+		List<HintDeclaration> hintDeclarations = hateoasHints.computeJacksonMappings(typeSystem, Collections.emptySet());
 		assertHints(hintDeclarations)
 				// Assert only the ones using jackson
 				.hasSize(7)

--- a/spring-native-configuration/src/test/java/org/springframework/hateoas/config/HateoasHintsTests.java
+++ b/spring-native-configuration/src/test/java/org/springframework/hateoas/config/HateoasHintsTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.config;
+
+import static org.springframework.nativex.hint.AccessBits.*;
+import static org.springframework.nativex.util.HintDeclarationsAssert.*;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.example.test.hateoas.Drink;
+import com.example.test.hateoas.DrinksModelProcessor;
+import com.example.test.hateoas.Person;
+import com.example.test.hateoas.PersonRepresentationModel;
+import com.example.test.hateoas.TypeUsingJackson;
+import com.example.test.hateoas.TypeUsingJacksonOnField;
+import com.example.test.hateoas.TypeUsingJacksonOnMethod;
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.nativex.type.HintDeclaration;
+import org.springframework.nativex.type.TypeSystem;
+
+public class HateoasHintsTests {
+
+	private TypeSystem typeSystem = new TypeSystem(Arrays.asList(new File("./target/classes").toString(), new File("./target/test-classes/com/example/test/hateoas").toString()));
+
+	private HateoasHints hateoasHints;
+
+	@Before
+	public void setUp() {
+		hateoasHints = new HateoasHints();
+	}
+
+	@Test
+	public void computesModelAndModelProcessorCorrectly() {
+
+		List<HintDeclaration> hintDeclarations = hateoasHints.computeRepresentationModels(typeSystem);
+
+		assertHints(hintDeclarations)
+				.hasSize(4)
+				.doesNotContainResourceConfiguration()
+				.extractReflectionConfigFor(PersonRepresentationModel.class, it -> it.hasAccessBits(FULL_REFLECTION))
+				.extractReflectionConfigFor(Person.class, it -> it.hasAccessBits(FULL_REFLECTION))
+				.extractReflectionConfigFor(DrinksModelProcessor.class, it -> it.hasAccessBits(FULL_REFLECTION))
+				.extractReflectionConfigFor(Drink.class, it -> it.hasAccessBits(FULL_REFLECTION));
+	}
+
+	@Test
+	public void jackson() {
+
+		List<HintDeclaration> hintDeclarations = hateoasHints.computeJacksonMappings(typeSystem);
+		assertHints(hintDeclarations)
+				// Assert only the ones using jackson
+				.hasSize(7)
+				// The domain types
+				.extractReflectionConfigFor(TypeUsingJackson.class, it -> it.hasAccessBits(FULL_REFLECTION))
+				.extractReflectionConfigFor(TypeUsingJacksonOnMethod.class, it -> it.hasAccessBits(FULL_REFLECTION))
+				.extractReflectionConfigFor(TypeUsingJacksonOnField.class, it -> it.hasAccessBits(FULL_REFLECTION))
+				// The used jackson annotations
+				.extractReflectionConfigFor(JsonClassDescription.class, it -> it.hasAccessBits(ANNOTATION))
+				.extractReflectionConfigFor(JacksonAnnotation.class, it -> it.hasAccessBits(ANNOTATION))
+				.extractReflectionConfigFor(JsonProperty.class, it -> it.hasAccessBits(ANNOTATION))
+				.extractReflectionConfigFor(JsonAlias.class, it -> it.hasAccessBits(ANNOTATION));
+	}
+}

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/DependantTypeAssert.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/DependantTypeAssert.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.util;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.springframework.nativex.type.AccessDescriptor;
+import org.springframework.nativex.type.HintDeclaration;
+
+public class DependantTypeAssert extends AbstractAssert<DependantTypeAssert, HintDeclaration> {
+
+	private String typeName;
+
+	public DependantTypeAssert(Class<?> type, HintDeclaration hintDeclaration) {
+		this(type.getName(), hintDeclaration);
+	}
+
+	public DependantTypeAssert(String typeName, HintDeclaration hintDeclaration) {
+
+		super(hintDeclaration, DependantTypeAssert.class);
+		this.typeName = typeName;
+	}
+
+	public DependantTypeAssert hasAccessBits(int accessBits) {
+		return hasAccessDescriptor(new AccessDescriptor(accessBits));
+	}
+
+	public DependantTypeAssert hasAccessDescriptor(AccessDescriptor accessDescriptor) {
+
+		isNotNull();
+		if (!actual.getDependantTypes().containsKey(typeName)) {
+			failWithMessage("Expected to contain reflection config for %s but was not in %s",
+					typeName, actual.getDependantTypes());
+		}
+
+		AccessDescriptor ad = actual.getDependantTypes().get(typeName);
+		Assertions.assertThat(ad.toString()).isEqualTo(accessDescriptor.toString());
+
+		return this;
+	}
+}

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.util;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.springframework.nativex.domain.proxies.ProxyDescriptor;
+import org.springframework.nativex.hint.AccessBits;
+import org.springframework.nativex.type.AccessDescriptor;
+import org.springframework.nativex.type.HintDeclaration;
+
+public class HintDeclarationAssert extends AbstractAssert<HintDeclarationAssert, HintDeclaration> {
+
+	public HintDeclarationAssert(HintDeclaration hintDeclaration) {
+		super(hintDeclaration, HintDeclarationAssert.class);
+	}
+
+	protected HintDeclarationAssert(HintDeclaration actual, Class selfType) {
+		super(actual, selfType);
+	}
+
+	public HintDeclarationAssert containsResources(String... resourcePatterns) {
+
+		isNotNull();
+		Assertions.assertThat(actual.getResourcesDescriptors()).isNotEmpty();
+
+		Assertions.assertThat(actual.getResourcesDescriptors().stream().flatMap(descriptor -> {
+			return Arrays.stream(descriptor.getPatterns());
+		})).contains(resourcePatterns);
+
+		return this;
+	}
+
+	public HintDeclarationAssert doesNotContainResources() {
+
+		Assertions.assertThat(actual.getResourcesDescriptors()).isNullOrEmpty();
+		return this;
+	}
+
+	public HintDeclarationAssert containsProxyFor(Class<?> type) {
+
+		if (!actual.getProxyDescriptors().stream().map(ProxyDescriptor::getTypes)
+				.anyMatch(types -> type.getName().equals(types.get(0)))) {
+
+			failWithMessage("Expected HintDeclaration to contain proxy config for %s but was not in %s",
+					type.getName(), actual.getProxyDescriptors());
+		}
+		return this;
+	}
+
+	public HintDeclarationAssert containsProxy(Class<?>... interfaces) {
+		return containsProxy(ProxyDescriptor.of(Arrays.stream(interfaces).map(Class::getName).collect(Collectors.toList())));
+	}
+
+	public HintDeclarationAssert containsProxy(ProxyDescriptor proxyDescriptor) {
+
+		Assertions.assertThat(actual.getProxyDescriptors()).contains(proxyDescriptor);
+		return this;
+	}
+
+	public HintDeclarationAssert doesNotContainsProxies() {
+
+		Assertions.assertThat(actual.getProxyDescriptors()).isNullOrEmpty();
+		return this;
+	}
+
+	public HintDeclarationAssert containsDependantType(Class<?> type, AccessBits accessBits) {
+		return containsDependantType(type.getName(), new AccessDescriptor(accessBits.getValue()));
+	}
+
+	public HintDeclarationAssert containsDependantType(Class<?> type, AccessDescriptor accessDescriptor) {
+		return containsDependantType(type.getName(), accessDescriptor);
+	}
+
+	public HintDeclarationAssert containsDependantType(String typeName, AccessDescriptor accessDescriptor) {
+
+		isNotNull();
+		Assertions.assertThat(actual.getDependantTypes()).containsEntry(typeName, accessDescriptor);
+		return this;
+	}
+}

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationsAssert.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationsAssert.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.util;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.assertj.core.api.AssertFactory;
+import org.assertj.core.api.FactoryBasedNavigableListAssert;
+import org.springframework.nativex.type.HintDeclaration;
+
+public class HintDeclarationsAssert extends FactoryBasedNavigableListAssert<HintDeclarationsAssert, List<? extends HintDeclaration>, HintDeclaration, HintDeclarationAssert> {
+
+	public HintDeclarationsAssert(List<? extends HintDeclaration> actual) {
+		this(actual, HintDeclarationsAssert.class);
+	}
+
+	protected HintDeclarationsAssert(List<? extends HintDeclaration> hintDeclarations, Class<?> selfType) {
+		super(hintDeclarations, HintDeclarationsAssert.class, new HintDeclarationsAssertFactory());
+	}
+
+	public static HintDeclarationsAssert assertHints(List<? extends HintDeclaration> hintDeclarations) {
+		return new HintDeclarationsAssert(hintDeclarations);
+	}
+
+	public DependantTypeAssert extractReflectionConfigFor(Class<?> type) {
+		return extractReflectionConfigFor(type.getName());
+	}
+
+	public HintDeclarationsAssert extractReflectionConfigFor(Class<?> type, Consumer<DependantTypeAssert> typeAssertConsumer) {
+
+		typeAssertConsumer.accept(extractReflectionConfigFor(type));
+		return this;
+	}
+
+	public DependantTypeAssert extractReflectionConfigFor(String type) {
+
+		Optional<? extends HintDeclaration> first = actual.stream().filter(it -> {
+			return it.getDependantTypes().containsKey(type);
+		}).findFirst();
+
+		if (!first.isPresent()) {
+			failWithMessage("Expected to find at least one HintDeclaration to contain reflection config for %s but was not in %s",
+					type, actual);
+		}
+
+		return new DependantTypeAssert(type, first.get());
+	}
+
+	public HintDeclarationsAssert doesNotContainResourceConfiguration() {
+
+		for (HintDeclaration hint : actual) {
+			new HintDeclarationAssert(hint).doesNotContainResources();
+		}
+		return this;
+	}
+
+	static public class HintDeclarationsAssertFactory implements AssertFactory<HintDeclaration, HintDeclarationAssert> {
+
+		@Override
+		public HintDeclarationAssert createAssert(HintDeclaration t) {
+			return new HintDeclarationAssert(t);
+		}
+	}
+}


### PR DESCRIPTION
This PR updates `HateoasHints` to scan for components that configure certain Hypermedia types such as _HAL_ and _UBER_ instead of maintaining static `@TypeHint` declarations.

User code and spring jars will also be scanned for usage of _Jackson2_ annotations, modules and de-/serializers, registering those as well as all jackson annotations on them.
Custom `RepresentationModels`, their `RepresentationModelProcessor` and the target domain types are also looked up and registered.

An optimization, that extracts the `HypermediaType` from `@EnableHypermediaSupport(type = {...})` and only registers the above mentioned hints for the configured formats, was moved to a separate commit (13d7abb) as we may want to introduce this in a later stage - feel free to drop it.