### PR TITLE
Refine TypeProcessor - allow scanning TypeSystem without repeating filters.

### DIFF
--- a/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel0.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel0.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.type.entities;
+
+public class MultiLevel0 implements InterfaceType {
+
+	MultiLevel1 toLevel1;
+}

--- a/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel1.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel1.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.type.entities;
+
+public class MultiLevel1 {
+
+	MultiLevel2 toLevel2;
+}

--- a/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel2.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel2.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.type.entities;
+
+public class MultiLevel2 {
+
+	MultiLevel3 toLevel3;
+}

--- a/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel3.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/type/entities/MultiLevel3.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.type.entities;
+
+public class MultiLevel3 {
+
+	String value;
+}

--- a/spring-native-configuration/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesHints.java
@@ -68,10 +68,8 @@ public class ConfigurationPropertiesHints implements NativeConfiguration {
 
 	private List<HintDeclaration> computeConfigurationPropertiesHints(TypeSystem typeSystem) {
 		return TypeProcessor.namedProcessor("ConfigurationPropertiesHints - ConfigurationProperties")
-				.skipTypesMatching(type -> type.isPartOfDomain("org.springframework.boot") ||
-						!(type.hasAnnotationInHierarchy(CONFIGURATION_PROPERTIES_ANNOTATION)))
-				.skipFieldInspection()
-				.skipConstructorInspection()
+				.filter(type -> type.hasAnnotationInHierarchy(CONFIGURATION_PROPERTIES_ANNOTATION) && !type.isPartOfDomain("org.springframework.boot"))
+				.limitInspectionDepth(0)
 				.onTypeDiscovered((type, context) -> {
 					Map<String, Integer> propertyTypesForAccess = type.processAsConfigurationProperties();
 					for (Map.Entry<String,Integer> entry: propertyTypesForAccess.entrySet()) {
@@ -79,7 +77,6 @@ public class ConfigurationPropertiesHints implements NativeConfiguration {
 					}
 				})
 				.use(typeSystem)
-				.toProcessTypes(ts -> ts.findTypesAnnotated(CONFIGURATION_PROPERTIES_ANNOTATION, true).stream().map(ts::resolveName)
-				);
+				.processTypes();
 	}
 }


### PR DESCRIPTION
Introduce `TypeProcessor.filter(...)` and `TypeProcessor.limitInspectionDepth(...)` to allow filtering candidate Types based on a single filter instead of repeated ones.
The inspection depth limit, defines the maximum number of hops allowed during signature traversal.

Given a structure like below, and a limit of `1`, the type registration callback is invoked for `Level0`, `SomeInterface`
and `Level1`, but not for `Level2`.
Setting the limit to `0`, the callback is only invoked for `Level0`.
```java
class Level0 implements SomeInterface {
    Level1 level1;
}
class Level1 {
    Level2 level2;
}
class Level2 {
    // ...
}
```
Along the lines introduce a `DiscoveryContext` that provides access to the `Path` that leads to a certain type. That way, type registration callbacks can decide upon more information.