### PR TITLE
Compute AotProxyHints for Spring HATEOAS.

### DIFF
--- a/samples/spring-hateoas/README.md
+++ b/samples/spring-hateoas/README.md
@@ -1,0 +1,13 @@
+Spring Boot project with Spring HATEOAS.
+
+Original Example taken from [spring-projects/spring-hateoas-examples](https://github.com/spring-projects/spring-hateoas-examples/tree/main/hypermedia).
+
+To build and run the native application packaged in a lightweight container:
+```
+mvn spring-boot:build-image
+docker-compose up
+```
+
+As an alternative, you can use `build.sh` (with a local GraalVM installation or combined with
+`run-dev-container.sh` at the root of `spring-native` project). See also the related issue
+[Take advantage of Paketo dev-oriented images](https://github.com/spring-projects-experimental/spring-native/issues/227).

--- a/samples/spring-hateoas/build.sh
+++ b/samples/spring-hateoas/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+RC=0
+
+${PWD%/*samples/*}/scripts/compileWithMaven.sh && ${PWD%/*samples/*}/scripts/test.sh || RC=$?
+
+exit $RC

--- a/samples/spring-hateoas/mvnw
+++ b/samples/spring-hateoas/mvnw
@@ -1,0 +1,310 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Maven2 Start Up Batch script
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   M2_HOME - location of maven2's installed home dir
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        export JAVA_HOME="`/usr/libexec/java_home`"
+      else
+        export JAVA_HOME="/Library/Java/Home"
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+if [ -z "$M2_HOME" ] ; then
+  ## resolve links - $0 may be a link to maven's home
+  PRG="$0"
+
+  # need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG="`dirname "$PRG"`/$link"
+    fi
+  done
+
+  saveddir=`pwd`
+
+  M2_HOME=`dirname "$PRG"`/..
+
+  # make it fully qualified
+  M2_HOME=`cd "$M2_HOME" && pwd`
+
+  cd "$saveddir"
+  # echo Using m2 at $M2_HOME
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --unix "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME="`(cd "$M2_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="`which javac`"
+  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=`which readlink`
+    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
+      if $darwin ; then
+        javaHome="`dirname \"$javaExecutable\"`"
+        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
+      else
+        javaExecutable="`readlink -f \"$javaExecutable\"`"
+      fi
+      javaHome="`dirname \"$javaExecutable\"`"
+      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="`which java`"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=`cd "$wdir/.."; pwd`
+    fi
+    # end of workaround
+  done
+  echo "${basedir}"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    echo "$(tr -s '\n' ' ' < "$1")"
+  fi
+}
+
+BASE_DIR=`find_maven_basedir "$(pwd)"`
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+if [ -r "$BASE_DIR/.mvn/wrapper/maven-wrapper.jar" ]; then
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Found .mvn/wrapper/maven-wrapper.jar"
+    fi
+else
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
+    fi
+    if [ -n "$MVNW_REPOURL" ]; then
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+    else
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+    fi
+    while IFS="=" read key value; do
+      case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
+      esac
+    done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Downloading from: $jarUrl"
+    fi
+    wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+    if $cygwin; then
+      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
+    fi
+
+    if command -v wget > /dev/null; then
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Found wget ... using wget"
+        fi
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget "$jarUrl" -O "$wrapperJarPath"
+        else
+            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Found curl ... using curl"
+        fi
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl -o "$wrapperJarPath" "$jarUrl" -f
+        else
+            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+        fi
+        
+    else
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Falling back to using Java to download"
+        fi
+        javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaClass=`cygpath --path --windows "$javaClass"`
+        fi
+        if [ -e "$javaClass" ]; then
+            if [ ! -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
+                if [ "$MVNW_VERBOSE" = true ]; then
+                  echo " - Compiling MavenWrapperDownloader.java ..."
+                fi
+                # Compiling the Java class
+                ("$JAVA_HOME/bin/javac" "$javaClass")
+            fi
+            if [ -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
+                # Running the downloader
+                if [ "$MVNW_VERBOSE" = true ]; then
+                  echo " - Running MavenWrapperDownloader.java ..."
+                fi
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$MAVEN_PROJECTBASEDIR")
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+if [ "$MVNW_VERBOSE" = true ]; then
+  echo $MAVEN_PROJECTBASEDIR
+fi
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --path --windows "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/samples/spring-hateoas/mvnw.cmd
+++ b/samples/spring-hateoas/mvnw.cmd
@@ -1,0 +1,182 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Maven2 Start Up Batch script
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM M2_HOME - location of maven2's installed home dir
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%HOME%\mavenrc_pre.bat" call "%HOME%\mavenrc_pre.bat"
+if exist "%HOME%\mavenrc_pre.cmd" call "%HOME%\mavenrc_pre.cmd"
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+
+FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %DOWNLOAD_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%HOME%\mavenrc_post.bat" call "%HOME%\mavenrc_post.bat"
+if exist "%HOME%\mavenrc_post.cmd" call "%HOME%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%" == "on" pause
+
+if "%MAVEN_TERMINATE_CMD%" == "on" exit %ERROR_CODE%
+
+exit /B %ERROR_CODE%

--- a/samples/spring-hateoas/pom.xml
+++ b/samples/spring-hateoas/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.experimental</groupId>
+		<artifactId>spring-native-sample-parent</artifactId>
+		<version>0.10.0-SNAPSHOT</version>
+		<relativePath>../maven-parent/pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.springframework.samples</groupId>
+	<artifactId>spring-hateoas</artifactId>
+	<name>Spring HATEOAS - Hypermedia</name>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<properties>
+		<java.version>1.8</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.experimental</groupId>
+			<artifactId>spring-native</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.atteo</groupId>
+			<artifactId>evo-inflector</artifactId>
+			<version>1.2.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.experimental</groupId>
+				<artifactId>spring-aot-maven-plugin</artifactId>
+				<configuration>
+					<removeSpelSupport>true</removeSpelSupport>
+					<removeYamlSupport>true</removeYamlSupport>
+					<removeXmlSupport>false</removeXmlSupport>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/DatabaseLoader.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/DatabaseLoader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import java.util.Arrays;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class DatabaseLoader {
+
+	@Bean
+	CommandLineRunner initDatabase(EmployeeRepository employeeRepository, ManagerRepository managerRepository) {
+		return args -> {
+
+			/*
+			 * Gather Gandalf's team
+			 */
+			Manager gandalf = managerRepository.save(new Manager("Gandalf"));
+
+			Employee frodo = employeeRepository.save(new Employee("Frodo", "ring bearer", gandalf));
+			Employee bilbo = employeeRepository.save(new Employee("Bilbo", "burglar", gandalf));
+
+			gandalf.setEmployees(Arrays.asList(frodo, bilbo));
+			managerRepository.save(gandalf);
+
+			/*
+			 * Put together Saruman's team
+			 */
+			Manager saruman = managerRepository.save(new Manager("Saruman"));
+
+			Employee sam = employeeRepository.save(new Employee("Sam", "gardener", saruman));
+
+			saruman.setEmployees(Arrays.asList(sam));
+
+			managerRepository.save(saruman);
+		};
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/Employee.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/Employee.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author Greg Turnquist
+ */
+@Entity
+class Employee {
+
+	@Id @GeneratedValue private Long id;
+	private String name;
+	private String role;
+
+	public Employee() {
+	}
+
+	/**
+	 * To break the recursive, bi-directional relationship, don't serialize {@literal manager}.
+	 */
+	@JsonIgnore @OneToOne private Manager manager;
+
+	Employee(String name, String role, Manager manager) {
+
+		this.name = name;
+		this.role = role;
+		this.manager = manager;
+	}
+
+	public Optional<Long> getId() {
+		return Optional.ofNullable(this.id);
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getRole() {
+		return role;
+	}
+
+	public void setRole(String role) {
+		this.role = role;
+	}
+
+	public Manager getManager() {
+		return manager;
+	}
+
+	public void setManager(Manager manager) {
+		this.manager = manager;
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeController.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeController.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Links;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Greg Turnquist
+ */
+@RestController
+class EmployeeController {
+
+	private final EmployeeRepository repository;
+	private final EmployeeRepresentationModelAssembler assembler;
+	private final EmployeeWithManagerResourceAssembler employeeWithManagerResourceAssembler;
+
+	EmployeeController(EmployeeRepository repository, EmployeeRepresentationModelAssembler assembler,
+			EmployeeWithManagerResourceAssembler employeeWithManagerResourceAssembler) {
+
+		this.repository = repository;
+		this.assembler = assembler;
+		this.employeeWithManagerResourceAssembler = employeeWithManagerResourceAssembler;
+	}
+
+	/**
+	 * Look up all employees, and transform them into a REST collection resource using
+	 * {@link EmployeeRepresentationModelAssembler#toCollectionModel(Iterable)}. Then return them through Spring Web's
+	 * {@link ResponseEntity} fluent API.
+	 */
+	@GetMapping("/employees")
+	public ResponseEntity<CollectionModel<EntityModel<Employee>>> findAll() {
+
+		return ResponseEntity.ok(assembler.toCollectionModel(repository.findAll()));
+
+	}
+
+	/**
+	 * Look up a single {@link Employee} and transform it into a REST resource using
+	 * {@link EmployeeRepresentationModelAssembler#toModel(Object)}. Then return it through Spring Web's
+	 * {@link ResponseEntity} fluent API.
+	 *
+	 * @param id
+	 */
+	@GetMapping("/employees/{id}")
+	public ResponseEntity<EntityModel<Employee>> findOne(@PathVariable long id) {
+
+		return repository.findById(id) //
+				.map(assembler::toModel) //
+				.map(ResponseEntity::ok) //
+				.orElse(ResponseEntity.notFound().build());
+	}
+
+	/**
+	 * Find an {@link Employee}'s {@link Manager} based upon employee id. Turn it into a context-based link.
+	 *
+	 * @param id
+	 * @return
+	 */
+	@GetMapping("/managers/{id}/employees")
+	public ResponseEntity<CollectionModel<EntityModel<Employee>>> findEmployees(@PathVariable long id) {
+
+		CollectionModel<EntityModel<Employee>> collectionModel = assembler
+				.toCollectionModel(repository.findByManagerId(id));
+
+		Links newLinks = collectionModel.getLinks().merge(Links.MergeMode.REPLACE_BY_REL,
+				linkTo(methodOn(EmployeeController.class).findEmployees(id)).withSelfRel());
+
+		return ResponseEntity.ok(CollectionModel.of(collectionModel.getContent(), newLinks));
+	}
+
+	@GetMapping("/employees/detailed")
+	public ResponseEntity<CollectionModel<EntityModel<EmployeeWithManager>>> findAllDetailedEmployees() {
+
+		return ResponseEntity.ok( //
+				employeeWithManagerResourceAssembler.toCollectionModel( //
+						StreamSupport.stream(repository.findAll().spliterator(), false) //
+								.map(EmployeeWithManager::new) //
+								.collect(Collectors.toList())));
+	}
+
+	@GetMapping("/employees/{id}/detailed")
+	public ResponseEntity<EntityModel<EmployeeWithManager>> findDetailedEmployee(@PathVariable Long id) {
+
+		return repository.findById(id) //
+				.map(EmployeeWithManager::new) //
+				.map(employeeWithManagerResourceAssembler::toModel) //
+				.map(ResponseEntity::ok) //
+				.orElse(ResponseEntity.notFound().build());
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeRepository.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Greg Turnquist
+ */
+interface EmployeeRepository extends CrudRepository<Employee, Long> {
+
+	List<Employee> findByManagerId(Long id);
+
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeRepresentationModelAssembler.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeRepresentationModelAssembler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class EmployeeRepresentationModelAssembler extends SimpleIdentifiableRepresentationModelAssembler<Employee> {
+
+	EmployeeRepresentationModelAssembler() {
+		super(EmployeeController.class);
+	}
+
+	/**
+	 * Define links to add to every {@link EntityModel}.
+	 *
+	 * @param resource
+	 */
+	@Override
+	public void addLinks(EntityModel<Employee> resource) {
+
+		/**
+		 * Add some custom links to the default ones provided. NOTE: To replace default links, don't invoke
+		 * {@literal super.addLinks()}.
+		 */
+		super.addLinks(resource);
+
+		resource.getContent().getId() //
+				.ifPresent(id -> { //
+					// Add additional links
+					resource.add(linkTo(methodOn(ManagerController.class).findManager(id)).withRel("manager"));
+					resource.add(linkTo(methodOn(EmployeeController.class).findDetailedEmployee(id)).withRel("detailed"));
+
+					// Maintain a legacy link to support older clients not yet adjusted to the switch from "supervisor" to
+					// "manager".
+					resource.add(linkTo(methodOn(SupervisorController.class).findOne(id)).withRel("supervisor"));
+				});
+	}
+
+	/**
+	 * Define links to add to {@link CollectionModel} collection.
+	 *
+	 * @param resources
+	 */
+	@Override
+	public void addLinks(CollectionModel<EntityModel<Employee>> resources) {
+
+		super.addLinks(resources);
+
+		resources.add(linkTo(methodOn(EmployeeController.class).findAllDetailedEmployees()).withRel("detailedEmployees"));
+		resources.add(linkTo(methodOn(ManagerController.class).findAll()).withRel("managers"));
+		resources.add(linkTo(methodOn(RootController.class).root()).withRel("root"));
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeWithManager.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeWithManager.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Class defined purely for hosting an "detailed" point of view for REST.
+ *
+ * @author Greg Turnquist
+ */
+@JsonPropertyOrder({"id", "name", "role", "manager"})
+public class EmployeeWithManager {
+
+	@JsonIgnore private final Employee employee;
+
+	public EmployeeWithManager(Employee employee) {
+		this.employee = employee;
+	}
+
+	public Long getId() {
+
+		return this.employee.getId() //
+				.orElseThrow(() -> new RuntimeException("Couldn't find anything."));
+	}
+
+	public String getName() {
+		return this.employee.getName();
+	}
+
+	public String getRole() {
+		return this.employee.getRole();
+	}
+
+	public String getManager() {
+		return this.employee.getManager().getName();
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeWithManagerResourceAssembler.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/EmployeeWithManagerResourceAssembler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.SimpleRepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class EmployeeWithManagerResourceAssembler implements SimpleRepresentationModelAssembler<EmployeeWithManager> {
+
+	/**
+	 * Define links to add to every individual {@link EntityModel}.
+	 *
+	 * @param resource
+	 */
+	@Override
+	public void addLinks(EntityModel<EmployeeWithManager> resource) {
+
+		resource.add(
+				linkTo(methodOn(EmployeeController.class).findDetailedEmployee(resource.getContent().getId())).withSelfRel());
+		resource.add(linkTo(methodOn(EmployeeController.class).findOne(resource.getContent().getId())).withRel("summary"));
+		resource.add(linkTo(methodOn(EmployeeController.class).findAllDetailedEmployees()).withRel("detailedEmployees"));
+	}
+
+	/**
+	 * Define links to add to the {@link CollectionModel} collection.
+	 *
+	 * @param resources
+	 */
+	@Override
+	public void addLinks(CollectionModel<EntityModel<EmployeeWithManager>> resources) {
+
+		resources.add(linkTo(methodOn(EmployeeController.class).findAllDetailedEmployees()).withSelfRel());
+		resources.add(linkTo(methodOn(EmployeeController.class).findAll()).withRel("employees"));
+		resources.add(linkTo(methodOn(ManagerController.class).findAll()).withRel("managers"));
+		resources.add(linkTo(methodOn(RootController.class).root()).withRel("root"));
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/Manager.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/Manager.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * @author Greg Turnquist
+ */
+@Entity
+class Manager {
+
+	@Id @GeneratedValue private Long id;
+	private String name;
+
+
+	/**
+	 * To break the recursive, bi-directional interface, don't serialize {@literal employees}.
+	 */
+	@JsonIgnore //
+	@OneToMany(mappedBy = "manager") //
+	private List<Employee> employees = new ArrayList<>();
+
+	Manager(String name) {
+		this.name = name;
+	}
+
+	public Manager() {
+	}
+
+	public Optional<Long> getId() {
+		return Optional.ofNullable(this.id);
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<Employee> getEmployees() {
+		return employees;
+	}
+
+	public void setEmployees(List<Employee> employees) {
+		this.employees = employees;
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/ManagerController.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/ManagerController.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Greg Turnquist
+ */
+@RestController
+class ManagerController {
+
+	private final ManagerRepository repository;
+	private final ManagerRepresentationModelAssembler assembler;
+
+	ManagerController(ManagerRepository repository, ManagerRepresentationModelAssembler assembler) {
+
+		this.repository = repository;
+		this.assembler = assembler;
+	}
+
+	/**
+	 * Look up all managers, and transform them into a REST collection resource using
+	 * {@link ManagerRepresentationModelAssembler#toCollectionModel(Iterable)}. Then return them through Spring Web's
+	 * {@link ResponseEntity} fluent API.
+	 */
+	@GetMapping("/managers")
+	ResponseEntity<CollectionModel<EntityModel<Manager>>> findAll() {
+
+		return ResponseEntity.ok( //
+				assembler.toCollectionModel(repository.findAll()));
+
+	}
+
+	/**
+	 * Look up a single {@link Manager} and transform it into a REST resource using
+	 * {@link ManagerRepresentationModelAssembler#toModel(Object)}. Then return it through Spring Web's
+	 * {@link ResponseEntity} fluent API.
+	 *
+	 * @param id
+	 */
+	@GetMapping("/managers/{id}")
+	ResponseEntity<EntityModel<Manager>> findOne(@PathVariable long id) {
+
+		return repository.findById(id) //
+				.map(assembler::toModel) //
+				.map(ResponseEntity::ok) //
+				.orElse(ResponseEntity.notFound().build());
+	}
+
+	/**
+	 * Find an {@link Employee}'s {@link Manager} based upon employee id. Turn it into a context-based link.
+	 *
+	 * @param id
+	 * @return
+	 */
+	@GetMapping("/employees/{id}/manager")
+	ResponseEntity<EntityModel<Manager>> findManager(@PathVariable long id) {
+
+		return ResponseEntity.ok( //
+				assembler.toModel(repository.findByEmployeesId(id)));
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/ManagerRepository.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/ManagerRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Greg Turnquist
+ */
+interface ManagerRepository extends CrudRepository<Manager, Long> {
+
+	/**
+	 * Navigate through the JPA relationship to find a {@link Manager} based on an {@link Employee}'s {@literal id}.
+	 * 
+	 * @param id
+	 * @return
+	 */
+	Manager findByEmployeesId(Long id);
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/ManagerRepresentationModelAssembler.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/ManagerRepresentationModelAssembler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class ManagerRepresentationModelAssembler extends SimpleIdentifiableRepresentationModelAssembler<Manager> {
+
+	ManagerRepresentationModelAssembler() {
+		super(ManagerController.class);
+	}
+
+	/**
+	 * Retain default links provided by {@link SimpleIdentifiableRepresentationModelAssembler}, but add extra ones to each
+	 * {@link Manager}.
+	 *
+	 * @param resource
+	 */
+	@Override
+	public void addLinks(EntityModel<Manager> resource) {
+		/**
+		 * Retain default links.
+		 */
+		super.addLinks(resource);
+
+		resource.getContent().getId() //
+				.ifPresent(id -> { //
+					// Add custom link to find all managed employees
+					resource.add(linkTo(methodOn(EmployeeController.class).findEmployees(id)).withRel("employees"));
+				});
+	}
+
+	/**
+	 * Retain default links for the entire collection, but add extra custom links for the {@link Manager} collection.
+	 *
+	 * @param resources
+	 */
+	@Override
+	public void addLinks(CollectionModel<EntityModel<Manager>> resources) {
+
+		super.addLinks(resources);
+
+		resources.add(linkTo(methodOn(EmployeeController.class).findAll()).withRel("employees"));
+		resources.add(linkTo(methodOn(EmployeeController.class).findAllDetailedEmployees()).withRel("detailedEmployees"));
+		resources.add(linkTo(methodOn(RootController.class).root()).withRel("root"));
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/RootController.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/RootController.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Greg Turnquist
+ */
+@RestController
+class RootController {
+
+	@GetMapping("/")
+	ResponseEntity<RepresentationModel> root() {
+
+		RepresentationModel model = new RepresentationModel();
+
+		model.add(linkTo(methodOn(RootController.class).root()).withSelfRel());
+		model.add(linkTo(methodOn(EmployeeController.class).findAll()).withRel("employees"));
+		model.add(linkTo(methodOn(EmployeeController.class).findAllDetailedEmployees()).withRel("detailedEmployees"));
+		model.add(linkTo(methodOn(ManagerController.class).findAll()).withRel("managers"));
+
+		return ResponseEntity.ok(model);
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/SimpleIdentifiableRepresentationModelAssembler.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/SimpleIdentifiableRepresentationModelAssembler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import java.lang.reflect.Field;
+
+import org.springframework.core.GenericTypeResolver;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.LinkBuilder;
+import org.springframework.hateoas.server.LinkRelationProvider;
+import org.springframework.hateoas.server.SimpleRepresentationModelAssembler;
+import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A {@link SimpleRepresentationModelAssembler} that mixes together a Spring web controller and a
+ * {@link LinkRelationProvider} to build links upon a certain strategy.
+ *
+ * @author Greg Turnquist
+ */
+public class SimpleIdentifiableRepresentationModelAssembler<T> implements SimpleRepresentationModelAssembler<T> {
+
+	/**
+	 * The Spring MVC class for the object from which links will be built.
+	 */
+	private final Class<?> controllerClass;
+	/**
+	 * A {@link LinkRelationProvider} to look up names of links as options for resource paths.
+	 */
+	private final LinkRelationProvider relProvider;
+
+	/**
+	 * A {@link Class} depicting the object's type.
+	 */
+	private final Class<?> resourceType;
+
+	/**
+	 * Default base path as empty.
+	 */
+	private String basePath = "";
+
+	/**
+	 * Default a assembler based on Spring MVC controller, resource type, and {@link LinkRelationProvider}. With this
+	 * combination of information, resources can be defined.
+	 *
+	 * @param controllerClass - Spring MVC controller to base links off of
+	 * @param relProvider
+	 * @see #setBasePath(String) to adjust base path to something like "/api"/
+	 */
+	public SimpleIdentifiableRepresentationModelAssembler(Class<?> controllerClass, LinkRelationProvider relProvider) {
+
+		this.controllerClass = controllerClass;
+		this.relProvider = relProvider;
+
+		// Find the "T" type contained in "T extends Identifiable<?>", e.g.
+		// SimpleIdentifiableRepresentationModelAssembler<User> -> User
+		this.resourceType = GenericTypeResolver.resolveTypeArgument(this.getClass(),
+				SimpleIdentifiableRepresentationModelAssembler.class);
+	}
+
+	/**
+	 * Alternate constructor that falls back to {@link EvoInflectorLinkRelationProvider}.
+	 *
+	 * @param controllerClass
+	 */
+	public SimpleIdentifiableRepresentationModelAssembler(Class<?> controllerClass) {
+		this(controllerClass, new EvoInflectorLinkRelationProvider());
+	}
+
+	/**
+	 * Add single item self link based on the object and link back to aggregate root of the {@literal T} domain type using
+	 * {@link LinkRelationProvider#getCollectionResourceRelFor(Class)}}.
+	 *
+	 * @param resource
+	 */
+	public void addLinks(EntityModel<T> resource) {
+
+		resource.add(getCollectionLinkBuilder().slash(getId(resource)).withSelfRel());
+		resource.add(getCollectionLinkBuilder().withRel(this.relProvider.getCollectionResourceRelFor(this.resourceType)));
+	}
+
+	private Object getId(EntityModel<T> resource) {
+
+		Field id = ReflectionUtils.findField(this.resourceType, "id");
+		ReflectionUtils.makeAccessible(id);
+
+		return ReflectionUtils.getField(id, resource.getContent());
+	}
+
+	/**
+	 * Add a self link to the aggregate root.
+	 *
+	 * @param resources
+	 */
+	public void addLinks(CollectionModel<EntityModel<T>> resources) {
+		resources.add(getCollectionLinkBuilder().withSelfRel());
+	}
+
+	/**
+	 * Build up a URI for the collection using the Spring web controller followed by the resource type transformed by the
+	 * {@link LinkRelationProvider}. Assumption is that an {@literal EmployeeController} serving up {@literal Employee}
+	 * objects will be serving resources at {@code /employees} and {@code /employees/1}. If this is not the case, simply
+	 * override this method in your concrete instance, or resort to overriding {@link #addLinks(EntityModel)} and
+	 * {@link #addLinks(CollectionModel)} where you have full control over exactly what links are put in the individual
+	 * and collection resources.
+	 *
+	 * @return
+	 */
+	protected LinkBuilder getCollectionLinkBuilder() {
+
+		WebMvcLinkBuilder linkBuilder = linkTo(this.controllerClass);
+
+		for (String pathComponent : (getPrefix() + this.relProvider.getCollectionResourceRelFor(this.resourceType))
+				.split("/")) {
+			if (!pathComponent.isEmpty()) {
+				linkBuilder = linkBuilder.slash(pathComponent);
+			}
+		}
+
+		return linkBuilder;
+	}
+
+	/**
+	 * Provide opportunity to override the base path for the URI.
+	 */
+	private String getPrefix() {
+		return getBasePath().isEmpty() ? "" : getBasePath() + "/";
+	}
+
+	public Class<?> getControllerClass() {
+		return controllerClass;
+	}
+
+	public LinkRelationProvider getRelProvider() {
+		return relProvider;
+	}
+
+	public Class<?> getResourceType() {
+		return resourceType;
+	}
+
+	public String getBasePath() {
+		return basePath;
+	}
+
+	public void setBasePath(String basePath) {
+		this.basePath = basePath;
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/SpringHateoasHypermediaApplication.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/SpringHateoasHypermediaApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Greg Turnquist
+ */
+@SpringBootApplication
+public class SpringHateoasHypermediaApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringHateoasHypermediaApplication.class, args);
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/Supervisor.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/Supervisor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Legacy representation. Contains older format of data. Fewer links because hypermedia at the time was an after
+ * thought.
+ *
+ * @author Greg Turnquist
+ */
+@JsonPropertyOrder({"id", "name", "employees"})
+class Supervisor {
+
+	@JsonIgnore private final Manager manager;
+
+	public Supervisor(Manager manager) {
+		this.manager = manager;
+	}
+
+	public Long getId() {
+
+		return this.manager.getId() //
+				.orElseThrow(() -> new RuntimeException("Couldn't find anything"));
+	}
+
+	public String getName() {
+		return this.manager.getName();
+	}
+
+	public List<String> getEmployees() {
+
+		return manager.getEmployees().stream() //
+				.map(employee -> employee.getName() + "::" + employee.getRole()) //
+				.collect(Collectors.toList());
+	}
+}

--- a/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/SupervisorController.java
+++ b/samples/spring-hateoas/src/main/java/org/springframework/hateoas/examples/SupervisorController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.examples;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Represent an older controller that has since been replaced with {@link ManagerController}. This controller is used to
+ * provide legacy routes, i.e. backwards compatibility.
+ *
+ * @author Greg Turnquist
+ */
+@RestController
+public class SupervisorController {
+
+	private final ManagerController controller;
+
+	public SupervisorController(ManagerController controller) {
+		this.controller = controller;
+	}
+
+	@GetMapping("/supervisors/{id}")
+	public ResponseEntity<EntityModel<Supervisor>> findOne(@PathVariable Long id) {
+
+		EntityModel<Manager> managerResource = controller.findOne(id).getBody();
+
+		EntityModel<Supervisor> supervisorResource = EntityModel.of( //
+				new Supervisor(managerResource.getContent()), //
+				managerResource.getLinks());
+
+		return ResponseEntity.ok(supervisorResource);
+	}
+}

--- a/samples/spring-hateoas/verify.sh
+++ b/samples/spring-hateoas/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+RESPONSE=`curl -s localhost:8080/managers/1/employees`
+if [[ "$RESPONSE" == *"Bilbo"* ]]; then
+  exit 0
+else
+  exit 1
+fi
+

--- a/spring-aot/src/main/java/org/springframework/aot/nativex/ConfigurationContributor.java
+++ b/spring-aot/src/main/java/org/springframework/aot/nativex/ConfigurationContributor.java
@@ -149,6 +149,10 @@ public class ConfigurationContributor implements BootstrapContributor {
 		List<AotProxyDescriptor> classProxyDescriptors = configurationCollector.getClassProxyDescriptors();
 		List<String> classProxyNames = new ArrayList<>();
 		for (AotProxyDescriptor classProxyDescriptor: classProxyDescriptors) {
+			if(context.getTypeSystem().resolve(classProxyDescriptor.getTargetClassType()) == null) {
+				logger.debug("Cannot reach class proxy target type of: "+classProxyDescriptor);
+				continue;
+			}
 			classProxyNames.add(generateBuildTimeClassProxy(classProxyDescriptor, context));
 		}
 		return classProxyNames;
@@ -170,6 +174,7 @@ public class ConfigurationContributor implements BootstrapContributor {
 		// TODO [build time proxies] is this parent OK?
 		URLClassLoader ucl = new URLClassLoader(urls,ConfigurationContributor.class.getClassLoader());
 		logger.debug("Creating build time class proxy for class "+c.getTargetClassType());
+
 		Unloaded<?> unloadedProxy = ProxyGenerator.getProxyBytes(c, ucl);
 		
 		Path primaryProxyFilepath = Paths.get(proxyConfiguration.getProxyClassName().replace(".", "/") + ".class");

--- a/spring-aot/src/main/java/org/springframework/nativex/support/ResourcesHandler.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/ResourcesHandler.java
@@ -44,6 +44,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.nativex.AotOptions;
 import org.springframework.nativex.domain.init.InitializationDescriptor;
+import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.domain.proxies.JdkProxyDescriptor;
 import org.springframework.nativex.domain.reflect.FieldDescriptor;
 import org.springframework.nativex.domain.reflect.MethodDescriptor;
@@ -477,6 +478,11 @@ public class ResourcesHandler extends Handler {
 				dynamicProxiesHandler.addProxy(Arrays.asList(interfaces));
 			}
 			return true;
+		}
+
+		@Override
+		public void addAotProxy(AotProxyDescriptor proxyDescriptor) {
+			dynamicProxiesHandler.addClassProxy(proxyDescriptor.getTargetClassType(), proxyDescriptor.getInterfaceTypes(), proxyDescriptor.getProxyFeatures());
 		}
 
 		@Override

--- a/spring-aot/src/main/java/org/springframework/nativex/type/Method.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Method.java
@@ -315,6 +315,10 @@ public class Method {
 					return true;
 				}
 				Type annotationType = typeSystem.Lresolve(an.desc, true);
+				if(annotationType == null) {
+					continue;
+				}
+
 				boolean metaUsage = annotationType.isMetaAnnotated(Type.fromLdescriptorToSlashed(Type.AtMapping)) ||
 						annotationType.isMetaAnnotated(Type.fromLdescriptorToSlashed(Type.AtMessageMapping));;
 				if (metaUsage) {

--- a/spring-aot/src/main/java/org/springframework/nativex/type/NativeContext.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/NativeContext.java
@@ -19,13 +19,14 @@ package org.springframework.nativex.type;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.Flag;
 
 /**
  * Allows plugins to the native image build process to participate in programmatic analysis of the application
  * and call back into the system to register proxies/reflective-access/etc.
- * 
+ *
  * @author Andy Clement
  * @author Christoph Strobl
  */
@@ -34,6 +35,26 @@ public interface NativeContext {
 	boolean addProxy(List<String> interfaces);
 
 	boolean addProxy(String... interfaces);
+
+	/**
+	 * Add a {@link org.springframework.nativex.domain.proxies.AotProxyDescriptor} for the given type (dotted type name).
+	 *
+	 * @param dottedClassName the dotted class name (eg. com.example.ToBeProxied).
+	 * @param interfaces must not be {@literal null}.
+	 * @param proxyFeatures the feature {@link org.springframework.nativex.hint.ProxyBits bits}.
+	 * @since 0.10
+	 */
+	default void addAotProxy(String dottedClassName, List<String> interfaces, int proxyFeatures) {
+		addAotProxy(new AotProxyDescriptor(dottedClassName, interfaces, proxyFeatures));
+	}
+
+	/**
+	 * Add the given {@link AotProxyDescriptor}.
+	 *
+	 * @param proxyDescriptor must not be {@literal null}.
+	 * @since 0.10
+	 */
+	void addAotProxy(AotProxyDescriptor proxyDescriptor);
 
 	TypeSystem getTypeSystem();
 
@@ -87,5 +108,4 @@ public interface NativeContext {
 
 	// TODO Should probably be named addResource and provide a isBundle parameter
 	void addResourceBundle(String string);
-
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/type/TypeProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/TypeProcessor.java
@@ -34,6 +34,7 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.nativex.domain.init.InitializationDescriptor;
+import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.domain.proxies.JdkProxyDescriptor;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.Flag;
@@ -1075,6 +1076,14 @@ public class TypeProcessor {
 		@Override
 		public boolean addProxy(String... interfaces) {
 			return addProxy(Arrays.asList(interfaces));
+		}
+
+		@Override
+		public void addAotProxy(AotProxyDescriptor proxyDescriptor) {
+
+			HintDeclaration hintDeclaration = new HintDeclaration();
+			hintDeclaration.addProxyDescriptor(proxyDescriptor);
+			proxyHints.add(hintDeclaration);
 		}
 
 		@Override

--- a/spring-aot/src/test/java/org/springframework/aot/NativeTestContext.java
+++ b/spring-aot/src/test/java/org/springframework/aot/NativeTestContext.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.Flag;
 import org.springframework.nativex.type.AccessDescriptor;
@@ -41,6 +42,7 @@ public class NativeTestContext implements NativeContext {
 	private final TypeSystem typeSystem;
 
 	MultiValueMap<String, List<String>> proxies;
+	MultiValueMap<String, AotProxyDescriptor> classProxies;
 	MultiValueMap<String, AccessDescriptor> reflection;
 	Set<Type> builtTimeInit;
 	Set<String> resources;
@@ -69,6 +71,11 @@ public class NativeTestContext implements NativeContext {
 	@Override
 	public boolean addProxy(String... interfaces) {
 		return addProxy(Arrays.asList(interfaces));
+	}
+
+	@Override
+	public void addAotProxy(AotProxyDescriptor proxyDescriptor) {
+		classProxies.add(proxyDescriptor.getTargetClassType(), proxyDescriptor);
 	}
 
 	@Override

--- a/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/web/config/DataRestHints.java
@@ -51,7 +51,6 @@ import reactor.core.publisher.Flux;
 				org.reactivestreams.Publisher.class,
 				HalMediaTypeConfiguration.class,
 
-				org.springframework.stereotype.Controller.class,
 				org.springframework.data.repository.core.support.RepositoryFactoryInformation.class,
 				org.springframework.data.repository.support.Repositories.class,
 				org.springframework.data.repository.support.RepositoryInvoker.class,
@@ -69,18 +68,6 @@ import reactor.core.publisher.Flux;
 
 						"org.springframework.data.rest.webmvc.config.WebMvcRepositoryRestConfiguration",
 
-						// PLUGIN
-						"org.springframework.plugin.core.support.PluginRegistryFactoryBean",
-						"org.springframework.plugin.core.OrderAwarePluginRegistry",
-						"org.springframework.plugin.core.Plugin",
-						"org.springframework.plugin.core.PluginRegistry",
-						"org.springframework.plugin.core.PluginRegistrySupport",
-						"org.springframework.plugin.core.SimplePluginRegistry",
-						"org.springframework.plugin.core.config.EnablePluginRegistries",
-						"org.springframework.plugin.core.config.PluginRegistriesBeanDefinitionRegistrar",
-						"org.springframework.plugin.core.support.AbstractTypeAwareSupport",
-						"org.springframework.plugin.core.support.PluginRegistryFactoryBean",
-
 						// JACKSON
 //						"org.springframework.hateoas.EntityModel$MapSuppressingUnwrappingSerializer",
 
@@ -95,18 +82,6 @@ import reactor.core.publisher.Flux;
 		jdkProxies = {
 				@JdkProxyHint(typeNames = {"org.springframework.data.rest.webmvc.BasePathAwareController", "org.springframework.core.annotation.SynthesizedAnnotation"}),
 				@JdkProxyHint(typeNames = {"org.springframework.data.rest.webmvc.RepositoryRestController", "org.springframework.data.rest.webmvc.BasePathAwareController", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"java.util.List", "org.springframework.aop.SpringProxy", "org.springframework.aop.framework.Advised", "org.springframework.core.DecoratingProxy"}),
-				@JdkProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestParam", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestBody", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"org.springframework.web.bind.annotation.PathVariable", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"org.springframework.web.bind.annotation.ModelAttribute", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"org.springframework.stereotype.Controller", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"org.springframework.web.bind.annotation.ControllerAdvice", "org.springframework.core.annotation.SynthesizedAnnotation"}),
-				@JdkProxyHint(typeNames = {"org.springframework.web.bind.annotation.RequestHeader", "org.springframework.core.annotation.SynthesizedAnnotation"})
-		},
-
-		initialization = {
-				@InitializationHint(types = {org.springframework.hateoas.MediaTypes.class, org.springframework.util.MimeTypeUtils.class}, initTime = InitializationTime.BUILD)
 		},
 		imports = {
 				WebMvcHints.class, HateoasHints.class

--- a/spring-native-configuration/src/main/java/org/springframework/plugin/PluginHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/plugin/PluginHints.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.plugin;
+
+import org.springframework.nativex.hint.AccessBits;
+import org.springframework.nativex.hint.TypeHint;
+
+@TypeHint(
+		types = {
+				org.springframework.plugin.core.support.PluginRegistryFactoryBean.class,
+				org.springframework.plugin.core.OrderAwarePluginRegistry.class,
+				org.springframework.plugin.core.Plugin.class,
+				org.springframework.plugin.core.PluginRegistry.class,
+				org.springframework.plugin.core.PluginRegistrySupport.class,
+				org.springframework.plugin.core.SimplePluginRegistry.class,
+				org.springframework.plugin.core.config.EnablePluginRegistries.class,
+				org.springframework.plugin.core.config.PluginRegistriesBeanDefinitionRegistrar.class,
+				org.springframework.plugin.core.support.AbstractTypeAwareSupport.class,
+				org.springframework.plugin.core.support.PluginRegistryFactoryBean.class,
+		},
+		access = AccessBits.ALL)
+public class PluginHints {
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/NativeTestContext.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/NativeTestContext.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.Flag;
 import org.springframework.nativex.type.AccessDescriptor;
@@ -42,6 +43,7 @@ public class NativeTestContext implements NativeContext {
 	private final TypeSystem typeSystem;
 
 	MultiValueMap<String, List<String>> proxies;
+	MultiValueMap<String, AotProxyDescriptor> classProxies;
 	MultiValueMap<String, AccessDescriptor> reflection;
 	Set<Type> builtTimeInit;
 	Set<String> resources;
@@ -70,6 +72,11 @@ public class NativeTestContext implements NativeContext {
 	@Override
 	public boolean addProxy(String... interfaces) {
 		return addProxy(Arrays.asList(interfaces));
+	}
+
+	@Override
+	public void addAotProxy(AotProxyDescriptor proxyDescriptor) {
+		classProxies.add(proxyDescriptor.getTargetClassType(), proxyDescriptor);
 	}
 
 	@Override

--- a/spring-native/src/main/java/org/springframework/aop/framework/ProxyGenerator.java
+++ b/spring-native/src/main/java/org/springframework/aop/framework/ProxyGenerator.java
@@ -147,7 +147,9 @@ public class ProxyGenerator {
 					}
 				}
 			}
-			doValidateClass(proxySuperClass.getSuperclass(), proxyClassLoader);
+			if(proxySuperClass.getSuperclass() != null) { // required?
+				doValidateClass(proxySuperClass.getSuperclass(), proxyClassLoader);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR computes required `ClassProxyHints` for Spring HATEOAS based on user code and spring jars.
It contains a dedicated Spring Boot sample application using HATEOAS and the required changes to `NativeContext` that allow dynamic registration of `ClassProxyDescriptor` and includes fixes for potential NPEs in `Method.isAtController()` and `proxySuperclass` lookup.

Related to: #356 