### PR TITLE
Add substitution for Spring Data MongoDB LazyLoadingProxies

### DIFF
--- a/samples/data-mongodb/src/main/java/com/example/data/mongo/Coupon.java
+++ b/samples/data-mongodb/src/main/java/com/example/data/mongo/Coupon.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.mongo;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class Coupon implements PriceReduction {
+
+	private @Id String id;
+	private String code;
+
+	public Coupon(String code) {
+		this.code = code;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+}

--- a/samples/data-mongodb/src/main/java/com/example/data/mongo/Order.java
+++ b/samples/data-mongodb/src/main/java/com/example/data/mongo/Order.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -36,6 +37,15 @@ public class Order {
 	private Date orderDate;
 
 	private List<LineItem> items;
+
+	@DBRef
+	private Coupon simpleRef;
+
+	@DBRef(lazy = true) // AotProxy
+	private Coupon coupon;
+
+	@DBRef(lazy = true) // JdkProxy
+	private PriceReduction reduction;
 
 	protected Order() {
 	}
@@ -107,6 +117,30 @@ public class Order {
 		this.items = items;
 	}
 
+	public Coupon getCoupon() {
+		return coupon;
+	}
+
+	public void setCoupon(Coupon coupon) {
+		this.coupon = coupon;
+	}
+
+	public void setReduction(PriceReduction reduction) {
+		this.reduction = reduction;
+	}
+
+	public PriceReduction getReduction() {
+		return reduction;
+	}
+
+	public Coupon getSimpleRef() {
+		return simpleRef;
+	}
+
+	public void setSimpleRef(Coupon simpleRef) {
+		this.simpleRef = simpleRef;
+	}
+
 	@Override
 	public String toString() {
 		return "Order{" +
@@ -114,6 +148,8 @@ public class Order {
 				", customerId='" + customerId + '\'' +
 				", orderDate=" + orderDate +
 				", items=" + items +
+				", coupon=" + coupon +
+				", reduction=" + reduction +
 				'}';
 	}
 }

--- a/samples/data-mongodb/src/main/java/com/example/data/mongo/PriceReduction.java
+++ b/samples/data-mongodb/src/main/java/com/example/data/mongo/PriceReduction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.mongo;
+
+public interface PriceReduction {
+
+	String getId();
+}

--- a/spring-aot/src/main/java/org/springframework/nativex/type/Field.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Field.java
@@ -18,15 +18,21 @@ package org.springframework.nativex.type;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.springframework.nativex.type.Type.TypeCollector;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Christoph Strobl
@@ -37,11 +43,13 @@ public class Field {
 	private TypeSystem typeSystem;
 
 	private Lazy<List<Type>> annotations;
+	private Lazy<List<String>> signatureTypes;
 
 	public Field(FieldNode node, TypeSystem typeSystem) {
 		this.node = node;
 		this.typeSystem = typeSystem;
 		this.annotations = Lazy.of(this::resolveAnnotations);
+		this.signatureTypes = Lazy.of(this::resolveSignatureTypes);
 	}
 
 	public List<Type> getAnnotationTypes() {
@@ -66,6 +74,68 @@ public class Field {
 		return results == null ? Collections.emptyList() : results;
 	}
 
+	public Map<String, String> getAnnotationValuesInHierarchy(String LdescriptorLookingFor) {
+		if (node.visibleAnnotations == null) {
+			return Collections.emptyMap();
+		}
+		Map<String, String> collector = new HashMap<>();
+		getAnnotationValuesInHierarchy(LdescriptorLookingFor, new ArrayList<>(), collector);
+		return collector;
+	}
+
+	public void getAnnotationValuesInHierarchy(String lookingFor, List<String> seen, Map<String, String> collector) {
+
+		if (node.visibleAnnotations != null) {
+			for (AnnotationNode anno : node.visibleAnnotations) {
+				if (seen.contains(anno.desc))
+					continue;
+				seen.add(anno.desc);
+				// logger.debug("Comparing "+anno.desc+" with "+lookingFor);
+				if (anno.desc.equals(lookingFor) && anno.values != null) {
+					List<Object> os = anno.values;
+					for (int i = 0; i < os.size(); i += 2) {
+						if(os.get(i+1) instanceof List) {
+
+							List<String> resolvedAttributeValues = new ArrayList<>();
+
+							for(Object attributeValue : (List)os.get(i+1)) {
+
+								if(!ObjectUtils.isArray(attributeValue)) {
+									resolvedAttributeValues.add(attributeValue.toString());
+									continue;
+								}
+
+								String attributeValueStringRepresentation = "";
+								String[] args = (String[]) attributeValue;
+								if(args[0].startsWith("L") && args[0].endsWith(";")) {
+									Type resolve = typeSystem.Lresolve(args[0], true);
+									if(resolve != null) {
+										attributeValueStringRepresentation = resolve.getDottedName();
+									}
+								}
+								if(args.length > 1) {
+									attributeValueStringRepresentation += ("." + args[1]);
+								}
+								resolvedAttributeValues.add(attributeValueStringRepresentation);
+							}
+							collector.put(os.get(i).toString(), StringUtils.collectionToDelimitedString(resolvedAttributeValues, ";"));
+						} else {
+							collector.put(os.get(i).toString(), os.get(i + 1).toString());
+						}
+					}
+				}
+				try {
+					Type resolve = typeSystem.Lresolve(anno.desc);
+					resolve.getAnnotationValuesInHierarchy(lookingFor, seen, collector);
+				} catch (MissingTypeException mte) {
+					// not on classpath, that's ok
+				}
+			}
+		}
+	}
+
+
+
 	/**
 	 * @return {@literal true} if considered a final field ({@link Opcodes#ACC_FINAL}).
 	 */
@@ -78,6 +148,34 @@ public class Field {
 	 */
 	public boolean isSynthetic() {
 		return (node.access & Opcodes.ACC_SYNTHETIC) != 0;
+	}
+
+	public Type getType() {
+		return getSignature().stream().map(typeSystem::resolveSlashed).findFirst().orElse(null);
+	}
+
+	private List<String> resolveSignatureTypes() {
+		if (node.signature == null) {
+			String s = node.desc;
+			List<String> types = new ArrayList<>();
+			if (s.startsWith("[")) {
+				s = s.substring(s.lastIndexOf("[")+1);
+			}
+			if (s.length()!=1) { // check for primitive
+				types.add(Type.fromLdescriptorToSlashed(s));
+			}
+			return types;
+		} else {
+			// Pull out all the types from the generic signature
+			SignatureReader reader = new SignatureReader(node.signature);
+			FieldSignatureCollector tc = new FieldSignatureCollector();
+			reader.accept(tc);
+			return tc.getTypes();
+		}
+	}
+
+	public List<String> getSignature() {
+		return new ArrayList<>(signatureTypes.get());
 	}
 
 	public Set<String> getTypesInSignature() {
@@ -102,5 +200,30 @@ public class Field {
 
 	public String getName() {
 		return node.name;
+	}
+
+	static class FieldSignatureCollector extends SignatureVisitor {
+
+		List<String> types = null;
+
+		public FieldSignatureCollector() {
+			super(Opcodes.ASM9);
+		}
+
+		@Override
+		public void visitClassType(String name) {
+			if (types == null) {
+				types = new ArrayList<>();
+			}
+			types.add(name);
+		}
+
+		public List<String> getTypes() {
+			if (types == null) {
+				return Collections.emptyList();
+			} else {
+				return types;
+			}
+		}
 	}
 }

--- a/spring-native/pom.xml
+++ b/spring-native/pom.xml
@@ -78,6 +78,11 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-mongodb</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>provided</scope>

--- a/spring-native/src/main/java/org/springframework/nativex/substitutions/data/Target_DefaultDbRefResolver.java
+++ b/spring-native/src/main/java/org/springframework/nativex/substitutions/data/Target_DefaultDbRefResolver.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.substitutions.data;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import com.mongodb.DBRef;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.cglib.proxy.MethodProxy;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+import org.springframework.data.mongodb.core.convert.DbRefProxyHandler;
+import org.springframework.data.mongodb.core.convert.DbRefResolverCallback;
+import org.springframework.data.mongodb.core.convert.LazyLoadingProxy;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import org.springframework.lang.Nullable;
+import org.springframework.nativex.substitutions.OnlyIfPresent;
+
+@TargetClass(className = "org.springframework.data.mongodb.core.convert.DefaultDbRefResolver", onlyWith = {OnlyIfPresent.class})
+public final class Target_DefaultDbRefResolver {
+
+	@Alias
+	private PersistenceExceptionTranslator exceptionTranslator = null;
+
+	@Substitute
+	private Object createLazyLoadingProxy(MongoPersistentProperty property, @Nullable DBRef dbref,
+			DbRefResolverCallback callback, DbRefProxyHandler handler) {
+
+		Class<?> propertyType = property.getType();
+		LazyLoadingInterceptor interceptor = new LazyLoadingInterceptor(property, dbref, exceptionTranslator, callback);
+
+		if (!propertyType.isInterface()) {
+
+			ProxyFactory factory = new ProxyFactory();
+			factory.addAdvice(interceptor);
+			factory.addInterface(LazyLoadingProxy.class);
+			factory.setTargetClass(propertyType);
+			factory.setProxyTargetClass(true);
+			return factory.getProxy(propertyType.getClassLoader());
+		}
+
+		ProxyFactory proxyFactory = new ProxyFactory();
+
+		for (Class<?> type : propertyType.getInterfaces()) {
+			proxyFactory.addInterface(type);
+		}
+
+		proxyFactory.addInterface(LazyLoadingProxy.class);
+		proxyFactory.addInterface(propertyType);
+		proxyFactory.addAdvice(interceptor);
+
+		return handler.populateId(property, dbref, proxyFactory.getProxy(LazyLoadingProxy.class.getClassLoader()));
+	}
+
+	@TargetClass(className = "org.springframework.data.mongodb.core.convert.DefaultDbRefResolver", innerClass = "LazyLoadingInterceptor", onlyWith = {OnlyIfPresent.class})
+	static final class LazyLoadingInterceptor implements MethodInterceptor, org.springframework.cglib.proxy.MethodInterceptor, Serializable {
+
+		@Alias
+		public LazyLoadingInterceptor(MongoPersistentProperty property, @Nullable DBRef dbref,
+				PersistenceExceptionTranslator exceptionTranslator, DbRefResolverCallback callback) {
+		}
+
+		@Alias
+		public Object invoke(MethodInvocation invocation) throws Throwable {
+			return null;
+		}
+
+		@Alias
+		public Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy) throws Throwable {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces support for Spring Data MongoDB references for linking documents by detecting fields annotated with `@DBRef` creating the required jdk/aop proxy configuration based on the `lazy` flag.

It also includes the substitution that makes sure the proxy creation within Spring Data MongoDB is routed to the `ProxyFactory`. This change was necessary to enable aop proxy generation but will no longer resolve proxy instances on `equals` or `hashCode`.

The substitution itself needs to be changed when upgrading to Spring Data MongoDB 3.3 as the proxy creation moved to another place.