### PR TITLE
Added hint to support spring-integration-jdbc dependency.

### DIFF
--- a/spring-native-configuration/pom.xml
+++ b/spring-native-configuration/pom.xml
@@ -85,6 +85,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-jdbc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-task-batch</artifactId>
             <scope>provided</scope>

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration;
 
+import org.springframework.integration.jdbc.store.JdbcMessageStore;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.InitializationHint;
 import org.springframework.nativex.hint.InitializationTime;
@@ -24,7 +25,15 @@ import org.springframework.nativex.hint.JdkProxyHint;
 import org.springframework.nativex.hint.ResourceHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
-
+@NativeHint(trigger = JdbcMessageStore.class,
+		resources = @ResourceHint(patterns = {
+				"org/springframework/integration/jdbc/schema-h2.sql",
+				"org/springframework/integration/jdbc/schema-mysql.sql",
+				"org/springframework/integration/jdbc/schema-oracle.sql",
+				"org/springframework/integration/jdbc/schema-postgresql.sql",
+				"org/springframework/integration/jdbc/schema-hsqldb.sql",
+				"org/springframework/integration/jdbc/schema-sqlserver.sql",
+				"org/springframework/integration/jdbc/schema-sybase.sql"}))
 @NativeHint(trigger = org.springframework.integration.config.EnableIntegration.class,
 		initialization =
 		@InitializationHint(initTime = InitializationTime.BUILD,


### PR DESCRIPTION
Currently if the `spring-integration-jdbc`  dependency is present in a project, then integration's schemas are not found.   As in the example below, schema-h2 is not found: 
```
     Caused by: org.springframework.jdbc.datasource.init.CannotReadScriptException: Cannot read SQL script from class path resource [org/springframework/integration/jdbc/schema-h2.sql]; nested exception is java.io.FileNotFoundException: class path resource [org/springframework/integration/jdbc/schema-h2.sql] cannot be opened because it does not exist
       org.springframework.jdbc.datasource.init.ScriptUtils.executeSqlScript(ScriptUtils.java:239)
       org.springframework.jdbc.datasource.init.ResourceDatabasePopulator.populate(ResourceDatabasePopulator.java:254)
       org.springframework.jdbc.datasource.init.DatabasePopulatorUtils.execute(DatabasePopulatorUtils.java:49)
       org.springframework.boot.jdbc.AbstractDataSourceInitializer.initialize(AbstractDataSourceInitializer.java:71)
       org.springframework.boot.jdbc.AbstractDataSourceInitializer.afterPropertiesSet(AbstractDataSourceInitializer.java:55)
       [...]
     Caused by: java.io.FileNotFoundException: class path resource [org/springframework/integration/jdbc/schema-h2.sql] cannot be opened because it does not exist
       org.springframework.core.io.ClassPathResource.getInputStream(ClassPathResource.java:187)
       org.springframework.core.io.support.EncodedResource.getReader(EncodedResource.java:146)
       org.springframework.jdbc.datasource.init.ScriptUtils.readScript(ScriptUtils.java:328)
       org.springframework.jdbc.datasource.init.ScriptUtils.executeSqlScript(ScriptUtils.java:236)
```

This PR adds a hint to resolve this issue.