### PR TITLE
Guard Spring Data MongoDB DbRefResolver substitution.

### DIFF
--- a/spring-native/src/main/java/org/springframework/nativex/substitutions/data/OnlyIfImperativeMongoClient.java
+++ b/spring-native/src/main/java/org/springframework/nativex/substitutions/data/OnlyIfImperativeMongoClient.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.nativex.substitutions.data;
+
+import java.util.function.BooleanSupplier;
+
+public class OnlyIfImperativeMongoClient implements BooleanSupplier {
+
+	@Override
+	public boolean getAsBoolean() {
+		try {
+			Class.forName("com.mongodb.client.MongoClient");
+			return true;
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
+	}
+}

--- a/spring-native/src/main/java/org/springframework/nativex/substitutions/data/Target_DefaultDbRefResolver.java
+++ b/spring-native/src/main/java/org/springframework/nativex/substitutions/data/Target_DefaultDbRefResolver.java
@@ -34,7 +34,7 @@ import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.nativex.substitutions.OnlyIfPresent;
 
-@TargetClass(className = "org.springframework.data.mongodb.core.convert.DefaultDbRefResolver", onlyWith = {OnlyIfPresent.class})
+@TargetClass(className = "org.springframework.data.mongodb.core.convert.DefaultDbRefResolver", onlyWith = {OnlyIfPresent.class, OnlyIfImperativeMongoClient.class})
 public final class Target_DefaultDbRefResolver {
 
 	@Alias
@@ -70,7 +70,7 @@ public final class Target_DefaultDbRefResolver {
 		return handler.populateId(property, dbref, proxyFactory.getProxy(LazyLoadingProxy.class.getClassLoader()));
 	}
 
-	@TargetClass(className = "org.springframework.data.mongodb.core.convert.DefaultDbRefResolver", innerClass = "LazyLoadingInterceptor", onlyWith = {OnlyIfPresent.class})
+	@TargetClass(className = "org.springframework.data.mongodb.core.convert.DefaultDbRefResolver", innerClass = "LazyLoadingInterceptor", onlyWith = {OnlyIfPresent.class, OnlyIfImperativeMongoClient.class})
 	static final class LazyLoadingInterceptor implements MethodInterceptor, org.springframework.cglib.proxy.MethodInterceptor, Serializable {
 
 		@Alias


### PR DESCRIPTION
`@DBRef` resolution only works for the imperative driver and is not supported by its reactive variant. This PR makes sure to guard the Substitution against potentially missing types only available via the sync MongoDB driver.

Fixes: #823