### PR TITLE
Remove adding superfluous ResourceDescriptor for AccessBits covering RESOURCE

### DIFF
--- a/spring-aot/src/main/java/org/springframework/nativex/type/TypeProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/TypeProcessor.java
@@ -1101,14 +1101,6 @@ public class TypeProcessor {
 
 			HintDeclaration hintDeclaration = new HintDeclaration();
 			hintDeclaration.addDependantType(typeName, descriptor);
-			if (requiresResourceAccess(descriptor)) {
-
-				String resourceName = TypeName.fromClassName(typeName.replace("[]", "")).toSlashName();
-				if (!resourceName.endsWith(".class")) {
-					resourceName = resourceName + ".class";
-				}
-				hintDeclaration.addResourcesDescriptor(new ResourcesDescriptor(new String[]{resourceName}, false));
-			}
 			reflectionHints.add(hintDeclaration);
 		}
 
@@ -1119,10 +1111,6 @@ public class TypeProcessor {
 			Set<String> added = new TreeSet<>();
 			registerHierarchy(type, added, accessBits);
 			return added;
-		}
-
-		private boolean requiresResourceAccess(AccessDescriptor accessDescriptor) {
-			return accessDescriptor.getAccessBits() != null && AccessBits.isSet(AccessBits.RESOURCE, accessDescriptor.getAccessBits());
 		}
 
 		private void registerHierarchy(Type type, Set<String> visited, int accessBits) {

--- a/spring-native-docs/src/main/asciidoc/support.adoc
+++ b/spring-native-docs/src/main/asciidoc/support.adoc
@@ -105,7 +105,6 @@ https://docs.spring.io/spring-data/commons/docs/current/reference/html/#reposito
 
 ==== Spring Data MongoDB
 
-- https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mapping-usage-references[Lazy loading references] are currently not supported.
 - https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.transactions[Multi Document Transactions] are currently not supported.
 
 [[support-others]]


### PR DESCRIPTION
This PR removes the piece of workaround code in `TypeProcessor` that made sure resource access was considered when computing configuration. This was actually fixed via 6412d4a.
The documentation hint for Spring Data MongoDB lazy loading DBRefs was also removed as those work now (see: #811)