### PR TITLE
Add more Spring Integration native hints

### DIFF
--- a/samples/integration/docker-compose.yml
+++ b/samples/integration/docker-compose.yml
@@ -1,6 +1,14 @@
 version: '3.1'
 services:
+  redis:
+    image: 'redis:latest'
+    ports:
+      - '6379:6379'
   integration:
     image: integration:0.0.1-SNAPSHOT
     ports:
-      - "8080:8080"
+      - '8080:8080'
+    depends_on:
+      - redis
+    environment:
+      - SPRING_REDIS_HOST=redis

--- a/samples/integration/pom.xml
+++ b/samples/integration/pom.xml
@@ -31,6 +31,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
@@ -40,6 +44,10 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-redis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>

--- a/samples/integration/pom.xml
+++ b/samples/integration/pom.xml
@@ -38,8 +38,17 @@
 			<artifactId>spring-integration-webflux</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-jdbc</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/samples/integration/pom.xml
+++ b/samples/integration/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<spring-integration.version>5.5.0-SNAPSHOT</spring-integration.version>
+		<spring-integration.version>5.5.2-SNAPSHOT</spring-integration.version>
 	</properties>
 
 	<dependencies>
@@ -35,7 +35,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-http</artifactId>
+			<artifactId>spring-integration-webflux</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>

--- a/samples/integration/pom.xml
+++ b/samples/integration/pom.xml
@@ -17,7 +17,6 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<spring-integration.version>5.5.2-SNAPSHOT</spring-integration.version>
 	</properties>
 
 	<dependencies>

--- a/samples/integration/src/main/java/com/example/integration/ControlBusGateway.java
+++ b/samples/integration/src/main/java/com/example/integration/ControlBusGateway.java
@@ -1,0 +1,10 @@
+package com.example.integration;
+
+import org.springframework.integration.annotation.MessagingGateway;
+
+@MessagingGateway(defaultRequestChannel = "controlBus.input")
+public interface ControlBusGateway {
+
+	void startEndpoint(String id);
+
+}

--- a/samples/integration/src/main/java/com/example/integration/ControlBusGateway.java
+++ b/samples/integration/src/main/java/com/example/integration/ControlBusGateway.java
@@ -1,10 +1,12 @@
 package com.example.integration;
 
+import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.MessagingGateway;
 
 @MessagingGateway(defaultRequestChannel = "controlBus.input")
 public interface ControlBusGateway {
 
+	@Gateway(payloadExpression = "'@' + args[0] + '.start()'")
 	void startEndpoint(String id);
 
 }

--- a/samples/integration/src/main/java/com/example/integration/IntegrationApplication.java
+++ b/samples/integration/src/main/java/com/example/integration/IntegrationApplication.java
@@ -6,9 +6,9 @@ import java.util.Date;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.interceptor.WireTap;
@@ -17,11 +17,12 @@ import org.springframework.integration.config.EnableMessageHistory;
 import org.springframework.integration.config.GlobalChannelInterceptor;
 import org.springframework.integration.config.IntegrationConverter;
 import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.integration.dsl.IntegrationFlows;
-import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.integration.handler.advice.RequestHandlerRetryAdvice;
 import org.springframework.integration.http.config.EnableIntegrationGraphController;
+import org.springframework.integration.webflux.dsl.WebFlux;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -35,8 +36,14 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 public class IntegrationApplication {
 
 	public static void main(String[] args) throws InterruptedException {
-		ConfigurableApplicationContext applicationContext = SpringApplication.run(IntegrationApplication.class, args);
-		applicationContext.getBean("dateSourceEndpoint", SourcePollingChannelAdapter.class).start();
+		SpringApplication.run(IntegrationApplication.class, args);
+
+		WebClient.create()
+				.get()
+				.uri("http://localhost:8080//control-bus/dateSourceEndpoint")
+				.retrieve()
+				.toBodilessEntity()
+				.block(Duration.ofSeconds(10));
 
 		Thread.sleep(1000);
 
@@ -97,6 +104,21 @@ public class IntegrationApplication {
 			}
 
 		};
+	}
+
+	@Bean
+	public IntegrationFlow controlBus() {
+		return IntegrationFlowDefinition::controlBus;
+	}
+
+	@Bean
+	public IntegrationFlow controlBusControllerFlow(ControlBusGateway controlBusGateway) {
+		return IntegrationFlows
+				.from(WebFlux.inboundChannelAdapter("/control-bus/{endpointId}")
+						.payloadExpression("#pathVariables.endpointId")
+						.requestMapping(mapping -> mapping.methods(HttpMethod.GET)))
+				.handle(controlBusGateway, "startEndpoint")
+				.get();
 	}
 
 }

--- a/samples/integration/src/main/java/com/example/integration/IntegrationApplication.java
+++ b/samples/integration/src/main/java/com/example/integration/IntegrationApplication.java
@@ -6,6 +6,7 @@ import java.util.Date;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
@@ -36,21 +37,32 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 public class IntegrationApplication {
 
 	public static void main(String[] args) throws InterruptedException {
-		SpringApplication.run(IntegrationApplication.class, args);
+		ApplicationContext context = SpringApplication.run(IntegrationApplication.class, args);
 
-		WebClient.create()
+		WebClient webClient =
+				context.getBean(WebClient.Builder.class)
+						.baseUrl("http://localhost:8080")
+						.build();
+
+		Thread.sleep(1000);
+
+		System.out.println("Starting 'dateSourceEndpoint'...");
+
+		webClient
 				.get()
-				.uri("http://localhost:8080//control-bus/dateSourceEndpoint")
+				.uri("control-bus/dateSourceEndpoint")
 				.retrieve()
 				.toBodilessEntity()
 				.block(Duration.ofSeconds(10));
 
 		Thread.sleep(1000);
 
+		System.out.println("Obtaining integration graph...");
+
 		String integrationGraph =
-				WebClient.create()
+				webClient
 						.get()
-						.uri("http://localhost:8080/integration-graph")
+						.uri("integration-graph")
 						.accept(MediaType.APPLICATION_JSON)
 						.retrieve()
 						.bodyToMono(String.class)

--- a/spring-native-configuration/pom.xml
+++ b/spring-native-configuration/pom.xml
@@ -472,6 +472,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-webflux</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-websocket</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/spring-native-configuration/pom.xml
+++ b/spring-native-configuration/pom.xml
@@ -486,6 +486,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-file</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-core</artifactId>
             <scope>provided</scope>

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -16,6 +16,9 @@
 
 package org.springframework.integration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.integration.jdbc.store.JdbcMessageStore;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.InitializationHint;
@@ -24,18 +27,13 @@ import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.JdkProxyHint;
 import org.springframework.nativex.hint.ResourceHint;
 import org.springframework.nativex.hint.TypeHint;
+import org.springframework.nativex.type.HintDeclaration;
 import org.springframework.nativex.type.NativeConfiguration;
-
+import org.springframework.nativex.type.TypeProcessor;
+import org.springframework.nativex.type.TypeSystem;
 
 @NativeHint(trigger = JdbcMessageStore.class,
-		resources = @ResourceHint(patterns = {
-				"org/springframework/integration/jdbc/schema-h2.sql",
-				"org/springframework/integration/jdbc/schema-mysql.sql",
-				"org/springframework/integration/jdbc/schema-oracle.sql",
-				"org/springframework/integration/jdbc/schema-postgresql.sql",
-				"org/springframework/integration/jdbc/schema-hsqldb.sql",
-				"org/springframework/integration/jdbc/schema-sqlserver.sql",
-				"org/springframework/integration/jdbc/schema-sybase.sql"}))
+		resources = @ResourceHint(patterns = "org/springframework/integration/jdbc/schema-.*.sql"))
 @NativeHint(trigger = org.springframework.integration.config.EnableIntegration.class,
 		initialization =
 		@InitializationHint(initTime = InitializationTime.BUILD,
@@ -50,6 +48,7 @@ import org.springframework.nativex.type.NativeConfiguration;
 		types = {
 				@TypeHint(access = AccessBits.FULL_REFLECTION,
 						types = {
+								org.springframework.integration.dsl.IntegrationFlow.class,
 								org.springframework.integration.gateway.RequestReplyExchanger.class,
 								org.springframework.integration.graph.Graph.class,
 								org.springframework.integration.graph.CompositeMessageHandlerNode.class,
@@ -96,6 +95,14 @@ import org.springframework.nativex.type.NativeConfiguration;
 								org.springframework.aop.SpringProxy.class,
 								org.springframework.aop.framework.Advised.class,
 								org.springframework.core.DecoratingProxy.class
+						}),
+				@JdkProxyHint(
+						types = {
+								org.springframework.integration.dsl.IntegrationFlow.class,
+								org.springframework.context.SmartLifecycle.class,
+								org.springframework.aop.SpringProxy.class,
+								org.springframework.aop.framework.Advised.class,
+								org.springframework.core.DecoratingProxy.class
 						})
 		})
 @NativeHint(trigger = org.springframework.integration.util.ClassUtils.class,
@@ -126,10 +133,45 @@ import org.springframework.nativex.type.NativeConfiguration;
 		@TypeHint(types = javax.xml.bind.Binder.class,
 				typeNames = "com.rometools.rome.feed.atom.Feed",
 				access = AccessBits.CLASS))
+@NativeHint(trigger = org.springframework.integration.http.inbound.IntegrationRequestMappingHandlerMapping.class,
+		types =
+		@TypeHint(
+				types = org.springframework.web.HttpRequestHandler.class,
+				access = AccessBits.CLASS | AccessBits.PUBLIC_METHODS))
+@NativeHint(trigger = org.springframework.integration.webflux.inbound.WebFluxIntegrationRequestMappingHandlerMapping.class,
+		types =
+		@TypeHint(
+				types = org.springframework.web.server.WebHandler.class,
+				access = AccessBits.CLASS | AccessBits.PUBLIC_METHODS))
 @NativeHint(trigger = com.fasterxml.jackson.databind.ObjectMapper.class,
 		initialization =
 		@InitializationHint(initTime = InitializationTime.BUILD,
 				types = org.springframework.integration.support.json.Jackson2JsonObjectMapper.class))
 public class IntegrationHints implements NativeConfiguration {
+
+	private static final String MESSAGING_GATEWAY_ANNOTATION =
+			"Lorg/springframework/integration/annotation/MessagingGateway;";
+
+	@Override
+	public List<HintDeclaration> computeHints(TypeSystem typeSystem) {
+		List<HintDeclaration> hints = new ArrayList<>();
+		hints.addAll(computeMessagingGatewayHints(typeSystem));
+		return hints;
+	}
+
+	private static List<HintDeclaration> computeMessagingGatewayHints(TypeSystem typeSystem) {
+		return TypeProcessor.namedProcessor("IntegrationHints - MessagingGateway")
+				.filter(type ->
+						type.hasAnnotationInHierarchy(MESSAGING_GATEWAY_ANNOTATION) &&
+								type.isInterface() &&
+								!type.isAnnotation())
+				.limitInspectionDepth(0)
+				.onTypeDiscovered((type, context) -> {
+					context.addProxy(type.getDottedName(), "org.springframework.aop.SpringProxy",
+							"org.springframework.aop.framework.Advised", "org.springframework.core.DecoratingProxy");
+				})
+				.use(typeSystem)
+				.processTypes();
+	}
 
 }

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -52,28 +52,17 @@ import org.springframework.nativex.type.TypeSystem;
 								org.springframework.integration.dsl.IntegrationFlow.class,
 								org.springframework.integration.gateway.RequestReplyExchanger.class,
 								org.springframework.integration.graph.Graph.class,
-								org.springframework.integration.graph.CompositeMessageHandlerNode.class,
-								org.springframework.integration.graph.DiscardingMessageHandlerNode.class,
-								org.springframework.integration.graph.EndpointNode.class,
-								org.springframework.integration.graph.ErrorCapableCompositeMessageHandlerNode.class,
-								org.springframework.integration.graph.ErrorCapableDiscardingMessageHandlerNode.class,
-								org.springframework.integration.graph.ErrorCapableEndpointNode.class,
-								org.springframework.integration.graph.ErrorCapableMessageHandlerNode.class,
-								org.springframework.integration.graph.ErrorCapableRoutingNode.class,
-								org.springframework.integration.graph.IntegrationNode.class,
-								org.springframework.integration.graph.LinkNode.class,
-								org.springframework.integration.graph.MessageChannelNode.class,
-								org.springframework.integration.graph.MessageGatewayNode.class,
-								org.springframework.integration.graph.MessageHandlerNode.class,
-								org.springframework.integration.graph.MessageProducerNode.class,
-								org.springframework.integration.graph.MessageSourceNode.class,
-								org.springframework.integration.graph.PollableChannelNode.class,
-								org.springframework.integration.graph.ReceiveCounters.class,
-								org.springframework.integration.graph.RoutingMessageHandlerNode.class,
 								org.springframework.integration.graph.SendTimers.class,
 								org.springframework.integration.graph.TimerStats.class,
 								org.springframework.integration.http.management.IntegrationGraphController.class,
-								org.springframework.integration.handler.AbstractReplyProducingMessageHandler.RequestHandler.class
+								org.springframework.integration.handler.AbstractReplyProducingMessageHandler.RequestHandler.class,
+								org.springframework.messaging.support.GenericMessage.class,
+								org.springframework.messaging.support.ErrorMessage.class,
+								org.springframework.integration.message.AdviceMessage.class,
+								org.springframework.integration.support.MutableMessage.class,
+								org.springframework.integration.store.MessageGroupMetadata.class,
+								org.springframework.integration.store.MessageHolder.class,
+								org.springframework.integration.store.MessageMetadata.class
 						}),
 				@TypeHint(access = AccessBits.CLASS | AccessBits.PUBLIC_METHODS,
 						types = {
@@ -158,6 +147,8 @@ public class IntegrationHints implements NativeConfiguration {
 
 	private static final String ABSTRACT_ENDPOINT_TYPE = "Lorg/springframework/integration/endpoint/AbstractEndpoint;";
 
+	private static final String INTEGRATION_NODE_TYPE = "Lorg/springframework/integration/graph/IntegrationNode;";
+
 	private static final String MESSAGE_TYPE = "org/springframework/messaging/Message";
 
 	@Override
@@ -165,6 +156,8 @@ public class IntegrationHints implements NativeConfiguration {
 		List<HintDeclaration> hints = new ArrayList<>();
 		hints.addAll(computeMessagingGatewayHints(typeSystem));
 		hints.addAll(computeAbstractEndpointHints(typeSystem));
+		hints.addAll(computeIntegrationNodeHints(typeSystem));
+//		TODO Fails with 'Unable to find class file for org/springframework/web/server/WebFilter' on 'spring-aot-maven-plugin:test-generate'
 //		hints.addAll(computeMessageHints(typeSystem));
 		return hints;
 	}
@@ -201,7 +194,21 @@ public class IntegrationHints implements NativeConfiguration {
 				.processTypes();
 	}
 
-/*	private static List<HintDeclaration> computeMessageHints(TypeSystem typeSystem) {
+	private static List<HintDeclaration> computeIntegrationNodeHints(TypeSystem typeSystem) {
+		return TypeProcessor.namedProcessor("IntegrationHints - IntegrationNode")
+				.skipAnnotationInspection()
+				.skipMethodInspection()
+				.skipFieldInspection()
+				.skipConstructorInspection()
+				.filter(type -> type.extendsClass(INTEGRATION_NODE_TYPE))
+				.onTypeDiscovered((type, context) ->
+						context.addReflectiveAccess(type,
+								new AccessDescriptor(AccessBits.FULL_REFLECTION)))
+				.use(typeSystem)
+				.processTypes();
+	}
+
+	private static List<HintDeclaration> computeMessageHints(TypeSystem typeSystem) {
 		return TypeProcessor.namedProcessor("IntegrationHints - Message")
 				.skipAnnotationInspection()
 				.skipMethodInspection()
@@ -213,6 +220,6 @@ public class IntegrationHints implements NativeConfiguration {
 								new AccessDescriptor(AccessBits.CLASS | AccessBits.PUBLIC_METHODS)))
 				.use(typeSystem)
 				.processTypes();
-	}*/
+	}
 
 }

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -17,15 +17,20 @@
 package org.springframework.integration;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
 
 import org.springframework.integration.jdbc.store.JdbcMessageStore;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.InitializationHint;
 import org.springframework.nativex.hint.InitializationTime;
-import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.JdkProxyHint;
+import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.ResourceHint;
+import org.springframework.nativex.hint.SerializationHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.AccessDescriptor;
 import org.springframework.nativex.type.HintDeclaration;
@@ -52,17 +57,12 @@ import org.springframework.nativex.type.TypeSystem;
 								org.springframework.integration.dsl.IntegrationFlow.class,
 								org.springframework.integration.gateway.RequestReplyExchanger.class,
 								org.springframework.integration.graph.Graph.class,
+								org.springframework.integration.graph.LinkNode.class,
 								org.springframework.integration.graph.SendTimers.class,
 								org.springframework.integration.graph.TimerStats.class,
+								org.springframework.integration.graph.ReceiveCounters.class,
 								org.springframework.integration.http.management.IntegrationGraphController.class,
-								org.springframework.integration.handler.AbstractReplyProducingMessageHandler.RequestHandler.class,
-								org.springframework.messaging.support.GenericMessage.class,
-								org.springframework.messaging.support.ErrorMessage.class,
-								org.springframework.integration.message.AdviceMessage.class,
-								org.springframework.integration.support.MutableMessage.class,
-								org.springframework.integration.store.MessageGroupMetadata.class,
-								org.springframework.integration.store.MessageHolder.class,
-								org.springframework.integration.store.MessageMetadata.class
+								org.springframework.integration.handler.AbstractReplyProducingMessageHandler.RequestHandler.class
 						}),
 				@TypeHint(access = AccessBits.CLASS | AccessBits.PUBLIC_METHODS,
 						types = {
@@ -72,6 +72,30 @@ import org.springframework.nativex.type.TypeSystem;
 								org.springframework.integration.gateway.MethodArgsHolder.class,
 								org.springframework.integration.routingslip.ExpressionEvaluatingRoutingSlipRouteStrategy.RequestAndReply.class,
 								org.springframework.integration.core.Pausable.class
+						})
+		},
+		serializables = {
+				@SerializationHint(
+						types = {
+								Number.class,
+								ArrayList.class,
+								HashMap.class,
+								Properties.class,
+								Hashtable.class,
+								Exception.class,
+								UUID.class,
+								org.springframework.messaging.support.GenericMessage.class,
+								org.springframework.messaging.support.ErrorMessage.class,
+								org.springframework.messaging.MessageHeaders.class,
+								org.springframework.integration.message.AdviceMessage.class,
+								org.springframework.integration.support.MutableMessage.class,
+								org.springframework.integration.support.MutableMessageHeaders.class,
+								org.springframework.integration.store.MessageGroupMetadata.class,
+								org.springframework.integration.store.MessageHolder.class,
+								org.springframework.integration.store.MessageMetadata.class,
+								org.springframework.integration.history.MessageHistory.class,
+								org.springframework.integration.history.MessageHistory.Entry.class,
+								org.springframework.integration.handler.DelayHandler.DelayedMessageWrapper.class
 						})
 		},
 		jdkProxies = {
@@ -113,6 +137,12 @@ import org.springframework.nativex.type.TypeSystem;
 						kotlin.Unit.class
 				},
 				access = AccessBits.CLASS | AccessBits.PUBLIC_METHODS))
+@NativeHint(trigger = org.springframework.integration.file.splitter.FileSplitter.class,
+		serializables =
+		@SerializationHint(types = {
+				org.springframework.integration.file.splitter.FileSplitter.FileMarker.class,
+				org.springframework.integration.file.splitter.FileSplitter.FileMarker.Mark.class,
+		}))
 @NativeHint(trigger = org.springframework.integration.xml.transformer.XsltPayloadTransformer.class,
 		types =
 		@TypeHint(types = org.springframework.web.context.support.ServletContextResource.class,
@@ -157,8 +187,8 @@ public class IntegrationHints implements NativeConfiguration {
 		hints.addAll(computeMessagingGatewayHints(typeSystem));
 		hints.addAll(computeAbstractEndpointHints(typeSystem));
 		hints.addAll(computeIntegrationNodeHints(typeSystem));
-//		TODO Fails with 'Unable to find class file for org/springframework/web/server/WebFilter' on 'spring-aot-maven-plugin:test-generate'
-//		hints.addAll(computeMessageHints(typeSystem));
+		//		TODO Fails with 'Unable to find class file for org/springframework/web/server/WebFilter' on 'spring-aot-maven-plugin:test-generate'
+		//		hints.addAll(computeMessageHints(typeSystem));
 		return hints;
 	}
 
@@ -188,8 +218,8 @@ public class IntegrationHints implements NativeConfiguration {
 				.skipConstructorInspection()
 				.filter(type -> type.extendsClass(ABSTRACT_ENDPOINT_TYPE))
 				.onTypeDiscovered((type, context) ->
-					context.addReflectiveAccess(type,
-							new AccessDescriptor(AccessBits.CLASS | AccessBits.PUBLIC_METHODS)))
+						context.addReflectiveAccess(type,
+								new AccessDescriptor(AccessBits.CLASS | AccessBits.PUBLIC_METHODS)))
 				.use(typeSystem)
 				.processTypes();
 	}


### PR DESCRIPTION
* The `IntegrationFlow` interface can be proxied at runtime
* The resource pattern for JDBC schemas should really be a regex pattern
* The HTTP and WebFlux request mappings need a reflection access to
method of their handlers to map
* Process interfaces with a `@MessagingGateway` and register their
proxy hints
* Improve `IntegrationApplication` in the sample to cover the mentioned
above cases about an `IntegrationFlow` proxy and `@MessagingGateway`