### PR TITLE
Add main class name to BuildContext

### DIFF
--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotSources.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotSources.java
@@ -102,7 +102,7 @@ public class GenerateAotSources extends DefaultTask {
 		try {
 			generator.generate(this.sourcesOutputDirectory.get().getAsFile().toPath(),
 					this.resourcesOutputDirectory.get().getAsFile().toPath(),
-					classpathElements, resourcesElements);
+					classpathElements, resourcesElements, null);
 		}
 		catch (IOException exc) {
 			throw new TaskExecutionException(this, exc);

--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
@@ -62,7 +62,7 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 		try {
 			List<String> runtimeClasspathElements = project.getRuntimeClasspathElements();
 			BootstrapCodeGenerator generator = new BootstrapCodeGenerator(getAotOptions());
-			generator.generate(sourcesPath, resourcesPath, runtimeClasspathElements, resourceFolders);
+			generator.generate(sourcesPath, resourcesPath, runtimeClasspathElements, resourceFolders, null);
 			compileGeneratedSources(sourcesPath, runtimeClasspathElements);
 			processGeneratedResources(resourcesPath, Paths.get(project.getBuild().getOutputDirectory()));
 			this.buildContext.refresh(this.buildDir);

--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/TestGenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/TestGenerateMojo.java
@@ -62,7 +62,7 @@ public class TestGenerateMojo extends AbstractBootstrapMojo {
 		try {
 			List<String> testClasspathElements = this.project.getTestClasspathElements();
 			BootstrapCodeGenerator generator = new BootstrapCodeGenerator(getAotOptions());
-			generator.generate(sourcesPath, resourcesPath, testClasspathElements, resourceFolders);
+			generator.generate(sourcesPath, resourcesPath, testClasspathElements, resourceFolders, null);
 			compileGeneratedTestSources(sourcesPath, testClasspathElements);
 			processGeneratedTestResources(resourcesPath, Paths.get(project.getBuild().getTestOutputDirectory()));
 			this.buildContext.refresh(this.buildDir);

--- a/spring-aot/src/main/java/org/springframework/aot/BootstrapCodeGenerator.java
+++ b/spring-aot/src/main/java/org/springframework/aot/BootstrapCodeGenerator.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.nativex.AotOptions;
 import org.springframework.nativex.domain.proxies.ProxiesDescriptor;
 import org.springframework.nativex.domain.proxies.ProxiesDescriptorJsonMarshaller;
@@ -64,11 +65,12 @@ public class BootstrapCodeGenerator {
 	 * @param resourcesPath the root path generated resource files should be written to
 	 * @param classpath the "compile+runtime" classpath of the application
 	 * @param resourceFolders paths to folders containing project main resources
+	 * @param mainClass main class name(FQDN)
 	 * @throws IOException if an I/O error is thrown when opening the resource folders
 	 */
-	public void generate(Path sourcesPath, Path resourcesPath, List<String> classpath, Set<Path> resourceFolders) throws IOException {
+	public void generate(Path sourcesPath, Path resourcesPath, List<String> classpath, Set<Path> resourceFolders, @Nullable String mainClass) throws IOException {
 		logger.debug("Starting code generation with classpath: " + classpath);
-		DefaultBuildContext buildContext = new DefaultBuildContext(classpath);
+		DefaultBuildContext buildContext = new DefaultBuildContext(mainClass, classpath);
 		ServiceLoader<BootstrapContributor> contributors = ServiceLoader.load(BootstrapContributor.class);
 		for (BootstrapContributor contributor : contributors) {
 			logger.debug("Executing Contributor: " + contributor.getClass().getName());

--- a/spring-aot/src/main/java/org/springframework/aot/BuildContext.java
+++ b/spring-aot/src/main/java/org/springframework/aot/BuildContext.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.springframework.core.type.classreading.TypeSystem;
+import org.springframework.lang.Nullable;
 import org.springframework.nativex.domain.proxies.ProxiesDescriptor;
 import org.springframework.nativex.domain.reflect.ReflectionDescriptor;
 import org.springframework.nativex.domain.resources.ResourcesDescriptor;
@@ -40,6 +41,13 @@ public interface BuildContext {
 	 * @return The {@link TypeSystem} based on the "compile+runtime" application classpath.
 	 */
 	TypeSystem getTypeSystem();
+
+	/**
+	 * Get the main class name if specified.
+	 * @return main class name or {@code null} if not specified
+	 */
+	@Nullable
+	String getMainClass();
 
 	/**
 	 * Contribute source files to the application.

--- a/spring-aot/src/main/java/org/springframework/aot/DefaultBuildContext.java
+++ b/spring-aot/src/main/java/org/springframework/aot/DefaultBuildContext.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.type.classreading.TypeSystem;
+import org.springframework.lang.Nullable;
 import org.springframework.nativex.domain.proxies.ProxiesDescriptor;
 import org.springframework.nativex.domain.reflect.ReflectionDescriptor;
 import org.springframework.nativex.domain.resources.ResourcesDescriptor;
@@ -43,6 +44,9 @@ import org.springframework.util.ReflectionUtils;
 class DefaultBuildContext implements BuildContext {
 
 	private final TypeSystem typeSystem;
+
+	@Nullable
+	private final String mainClass;
 
 	private final List<String> classpath;
 
@@ -61,7 +65,12 @@ class DefaultBuildContext implements BuildContext {
 	private final ReflectionDescriptor jniReflectionDescriptor = new ReflectionDescriptor();
 
 	DefaultBuildContext(List<String> classpath) {
+		this(null, classpath);
+	}
+
+	DefaultBuildContext(@Nullable String mainClass, List<String> classpath) {
 		this.classpath = classpath;
+		this.mainClass = mainClass;
 		this.typeSystem = TypeSystem.getTypeSystem(new DefaultResourceLoader(getBootstrapClassLoader(classpath)));
 	}
 
@@ -73,6 +82,11 @@ class DefaultBuildContext implements BuildContext {
 	@Override
 	public List<String> getClasspath() {
 		return this.classpath;
+	}
+
+	@Override
+	public String getMainClass() {
+		return this.mainClass;
 	}
 
 	@Override

--- a/spring-aot/src/main/java/org/springframework/aot/nativex/ConfigurationContributor.java
+++ b/spring-aot/src/main/java/org/springframework/aot/nativex/ConfigurationContributor.java
@@ -108,8 +108,11 @@ public class ConfigurationContributor implements BootstrapContributor {
 	}
 
 	private String getMainClass(BuildContext context) {
+		String mainClass = context.getMainClass();
+		if (mainClass != null) {
+			return mainClass;
+		}
 		for (String path : context.getClasspath()) {
-			String mainClass = null;
 			try {
 				mainClass = MainClassFinder.findSingleMainClass(new File(path));
 			}


### PR DESCRIPTION
Add the main class name to `BuildContext` to pass it down to the code generation.

This change provides a way to support a case when multiple main methods exist in the classpath. (#896)
Once the gradle and maven plugins are updated to take a main class name, `BuildContext` can hold the value and the code generation step can reference the specified main class.
