### PR TITLE
Fix JDBC auditing.

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/data/jdbc/repository/config/DataJdbcHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/jdbc/repository/config/DataJdbcHints.java
@@ -1,0 +1,18 @@
+package org.springframework.data.jdbc.repository.config;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.data.DataAuditingHints;
+import org.springframework.data.DataNonReactiveAuditingHints;
+import org.springframework.data.relational.core.mapping.event.RelationalAuditingCallback;
+import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.TypeHint;
+import org.springframework.nativex.type.NativeConfiguration;
+
+@Import(DataAuditingHints.class)
+@NativeHint(
+		trigger = JdbcAuditingRegistrar.class,
+		types = @TypeHint(types = RelationalAuditingCallback.class),
+		imports = DataNonReactiveAuditingHints.class
+)
+public class DataJdbcHints implements NativeConfiguration {
+}

--- a/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.NativeConfiguration
+++ b/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.NativeConfiguration
@@ -103,6 +103,7 @@ org.springframework.core.annotation.CoreAnnotationHints
 org.springframework.data.SpringDataCommonsHints
 org.springframework.data.DataAuditingHints
 org.springframework.data.elasticsearch.config.DataElasticSearchHints
+org.springframework.data.jdbc.repository.config.DataJdbcHints
 org.springframework.data.jpa.repository.config.DataJpaHints
 org.springframework.data.mongodb.config.MongoDbHints
 org.springframework.data.neo4j.config.Neo4jHints


### PR DESCRIPTION
For some reason DataJdbcHints.java was removed in 8a54bbd0d.
It is now back again and adapted to the evolved infrastructure.