### PR TITLE
Add more support with Spring for Apache Kafka

### DIFF
--- a/samples/kafka/docker-compose.yml
+++ b/samples/kafka/docker-compose.yml
@@ -1,18 +1,21 @@
 version: '3'
 services:
-    kafka:
-      image: wurstmeister/kafka
-      ports:
-        - "9092:9092"
-      environment:
-        - KAFKA_ADVERTISED_HOST_NAME=127.0.0.1
-        - KAFKA_ADVERTISED_PORT=9092
-        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      depends_on:
-        - zookeeper
     zookeeper:
       image: wurstmeister/zookeeper
       ports:
-        - "2181:2181"
+        - '2181:2181'
+    kafka:
+      image: wurstmeister/kafka
+      ports:
+        - '9092:9092'
+      depends_on:
+        - zookeeper
       environment:
-        - KAFKA_ADVERTISED_HOST_NAME=zookeeper
+        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+        - KAFKA_ADVERTISED_HOST_NAME=kafka
+    kafka-sample:
+      image: kafka:0.0.1-SNAPSHOT
+      depends_on:
+        - kafka
+      environment:
+        - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092

--- a/samples/kafka/docker-compose.yml
+++ b/samples/kafka/docker-compose.yml
@@ -1,21 +1,18 @@
 version: '3'
 services:
-    zookeeper:
-      image: wurstmeister/zookeeper
-      ports:
-        - '2181:2181'
     kafka:
       image: wurstmeister/kafka
       ports:
-        - '9092:9092'
+        - "9092:9092"
+      environment:
+        - KAFKA_ADVERTISED_HOST_NAME=127.0.0.1
+        - KAFKA_ADVERTISED_PORT=9092
+        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
       depends_on:
         - zookeeper
+    zookeeper:
+      image: wurstmeister/zookeeper
+      ports:
+        - "2181:2181"
       environment:
-        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-        - KAFKA_ADVERTISED_HOST_NAME=kafka
-    kafka-sample:
-      image: kafka:0.0.1-SNAPSHOT
-      depends_on:
-        - kafka
-      environment:
-        - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+        - KAFKA_ADVERTISED_HOST_NAME=zookeeper

--- a/samples/kafka/pom.xml
+++ b/samples/kafka/pom.xml
@@ -17,6 +17,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+		<spring-kafka.version>2.7.5-SNAPSHOT</spring-kafka.version>
 	</properties>
 
 	<dependencies>

--- a/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
+++ b/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
@@ -10,7 +10,12 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.nativex.hint.TypeHint;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@TypeHint(types = KafkaApplication.Greeting.class)
 @SpringBootApplication
 public class KafkaApplication {
 
@@ -19,7 +24,7 @@ public class KafkaApplication {
 	}
 
 	@KafkaListener(id = "graal", topics = "graal")
-	public void listen(String in) {
+	public void listen(Greeting in) {
 		System.out.println("++++++Received:" + in);
 	}
 
@@ -29,15 +34,38 @@ public class KafkaApplication {
 	}
 
 	@Bean
-	public ApplicationRunner runner(KafkaTemplate<String, String> template,
-				ConsumerFactory<String, String> cf) {
+	public ApplicationRunner runner(KafkaTemplate<String, Greeting> template,
+			ConsumerFactory<String, Greeting> cf) {
 
-		cf.addListener(new ConsumerFactory.Listener() { });
+		cf.addListener(new ConsumerFactory.Listener() {
+
+		});
 		return args -> {
-			template.send("graal", "foo");
+			template.send("graal", new Greeting("Hello from GraalVM!"));
 			System.out.println("++++++Sent:foo");
 			Thread.sleep(5000);
 		};
+	}
+
+	public static class Greeting {
+
+		private final String message;
+
+		@JsonCreator
+		public Greeting(@JsonProperty("message") String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return this.message;
+		}
+
+		@Override public String toString() {
+			return "Greeting{" +
+					"message='" + this.message + '\'' +
+					'}';
+		}
+
 	}
 
 }

--- a/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
+++ b/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
@@ -25,7 +25,7 @@ public class KafkaApplication {
 
 	@KafkaListener(id = "graal", topics = "graal")
 	public void listen(Greeting in) {
-		System.out.println("++++++Received:" + in);
+		System.out.println("++++++Received: " + in);
 	}
 
 	@Bean

--- a/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
+++ b/samples/kafka/src/main/java/com/example/kafka/KafkaApplication.java
@@ -37,12 +37,13 @@ public class KafkaApplication {
 	public ApplicationRunner runner(KafkaTemplate<String, Greeting> template,
 			ConsumerFactory<String, Greeting> cf) {
 
-		cf.addListener(new ConsumerFactory.Listener() {
+		cf.addListener(new ConsumerFactory.Listener<String, Greeting>() {
 
 		});
 		return args -> {
-			template.send("graal", new Greeting("Hello from GraalVM!"));
-			System.out.println("++++++Sent:foo");
+			Greeting data = new Greeting("Hello from GraalVM!");
+			template.send("graal", data);
+			System.out.println("++++++Sent: " + data);
 			Thread.sleep(5000);
 		};
 	}

--- a/samples/kafka/src/main/resources/application.properties
+++ b/samples/kafka/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties[spring.json.trusted.packages]=com.example.kafka
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer

--- a/samples/kafka/verify.sh
+++ b/samples/kafka/verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 sleep 2
-if [[ `cat target/native/test-output.txt | grep "++++++Received:foo"` ]]; then
+if [[ `cat target/native/test-output.txt | grep "++++++Received: Greeting{message='Hello from GraalVM!'}"` ]]; then
 	exit 0
 else
 	exit 1

--- a/spring-native-configuration/src/main/java/org/springframework/kafka/annotation/KafkaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/kafka/annotation/KafkaHints.java
@@ -53,8 +53,11 @@ import org.springframework.kafka.listener.ConsumerProperties;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.LoggingProducerListener;
 import org.springframework.kafka.support.ProducerListener;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.nativex.hint.AccessBits;
+import org.springframework.nativex.hint.InitializationHint;
+import org.springframework.nativex.hint.InitializationTime;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.JdkProxyHint;
 import org.springframework.nativex.hint.TypeHint;
@@ -118,6 +121,7 @@ import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 				DefaultPartitioner.class,
 				StringDeserializer.class,
 				StringSerializer.class,
+				JsonDeserializer.class,
 				JsonSerializer.class,
 				ByteArrayDeserializer.class,
 				ByteArraySerializer.class
@@ -173,5 +177,16 @@ import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 		})
 	}
 )
+@NativeHint(trigger = com.fasterxml.jackson.databind.ObjectMapper.class,
+		initialization =
+		@InitializationHint(initTime = InitializationTime.BUILD,
+				types = {
+				org.springframework.kafka.support.JacksonUtils.class,
+						org.springframework.kafka.support.JacksonPresent.class
+		}))
+@NativeHint(trigger = io.micrometer.core.instrument.MeterRegistry.class,
+		initialization =
+		@InitializationHint(initTime = InitializationTime.BUILD,
+				types = org.springframework.kafka.support.KafkaUtils.class))
 public class KafkaHints implements NativeConfiguration {
 }


### PR DESCRIPTION
* Add missed `JsonDeserializer` into type hints
* Add `@InitializationHint` for some `spring-kafka` JSON components
which need to initialize their `static` props for `ClassUtils.isPresent()`
* Improve `kafka` sample for JSON data interaction
* Add a `@TypeHint` for end-user data classes used in the sample
* Improve `docker-compose.yml` for extra image of the current `kafka` sample