### PR TITLE
Improve transactional proxy detection to generate needed proxy hints

### DIFF
--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterface.java
@@ -1,0 +1,14 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterface implements TransactionalInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndExtraInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndExtraInterface.java
@@ -1,0 +1,14 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceAndExtraInterface implements TransactionalInterface, VoidInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndExtraInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndExtraInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndOtherMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndOtherMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndOtherMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceAndOtherMethod.java
@@ -1,0 +1,18 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceAndOtherMethod implements TransactionalInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+    public void bar() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyClass.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyClass.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyClass.java
@@ -1,0 +1,9 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceOverProxyClass extends ProxyClass {
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceOverProxyInterface.java
@@ -1,0 +1,14 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceOverProxyInterface implements ProxyInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithDefault.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithDefault.java
@@ -1,0 +1,9 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceWithDefault implements TransactionalInterfaceWithDefault {
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithDefault.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithDefault.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethod.java
@@ -1,0 +1,9 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// no proxy needed
+@Component
+public class ComponentWithTransactionalInterfaceWithoutMethod implements TransactionalInterfaceWithoutMethod {
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
@@ -1,0 +1,13 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+
+// needs aot proxy
+@Component
+public class ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod implements TransactionalInterfaceWithoutMethod {
+
+    public void bar() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalMethod.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-// aot proxy
+// needs aot proxy
 @Component
 public class ComponentWithTransactionalMethod {
 

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ComponentWithTransactionalMethod.java
@@ -1,0 +1,15 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// aot proxy
+@Component
+public class ComponentWithTransactionalMethod {
+
+    @Transactional
+    public void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyClass.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyClass.java
@@ -1,0 +1,10 @@
+package app.main.hierarchy;
+
+public class ProxyClass implements TransactionalInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyClass.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 public class ProxyClass implements TransactionalInterface {

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 public interface ProxyInterface extends TransactionalInterface {

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/ProxyInterface.java
@@ -1,0 +1,5 @@
+package app.main.hierarchy;
+
+public interface ProxyInterface extends TransactionalInterface {
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalComponent.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalComponent.java
@@ -1,0 +1,15 @@
+package app.main.hierarchy;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// needs aot proxy
+@Transactional
+@Component
+public class TransactionalComponent {
+
+    public void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalComponent.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalComponent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.stereotype.Component;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterface.java
@@ -1,0 +1,10 @@
+package app.main.hierarchy;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TransactionalInterface {
+
+    void foo();
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.transaction.annotation.Transactional;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithDefault.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithDefault.java
@@ -1,0 +1,12 @@
+package app.main.hierarchy;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TransactionalInterfaceWithDefault {
+
+    default void foo() {
+
+    }
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithDefault.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithDefault.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.transaction.annotation.Transactional;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithoutMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithoutMethod.java
@@ -1,0 +1,8 @@
+package app.main.hierarchy;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TransactionalInterfaceWithoutMethod {
+
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithoutMethod.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/TransactionalInterfaceWithoutMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 import org.springframework.transaction.annotation.Transactional;

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/VoidInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/VoidInterface.java
@@ -1,0 +1,4 @@
+package app.main.hierarchy;
+
+public interface VoidInterface {
+}

--- a/samples/data-jpa/src/main/java/app/main/hierarchy/VoidInterface.java
+++ b/samples/data-jpa/src/main/java/app/main/hierarchy/VoidInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.main.hierarchy;
 
 public interface VoidInterface {

--- a/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
@@ -2357,28 +2357,7 @@ public class Type {
 	 * @return true if type or a method inside is marked @Transactional
 	 */
 	public boolean isTransactional() {
-		// TODO are these usable as meta annotations?
-		return isAnnotated(AtTransactional) || isAnnotated(AtJavaxTransactional);
-	}
-
-	public boolean hasTransactionalMethods() {
-		// TODO meta annotation usage?
-		List<Method> methodsWithAtTransactional = getMethodsWithAnnotation(AtTransactional);
-		if (methodsWithAtTransactional.size() > 0) {
-			return true;
-		}
-		List<Method> methodsWithAtJavaxTransactional = getMethodsWithAnnotation(AtJavaxTransactional);
-		if (methodsWithAtJavaxTransactional.size() > 0) {
-			return true;
-		}
-		return false;
-	}
-	
-	public List<Method> getTransactionalMethods() {
-		List<Method> results = new ArrayList<>();
-		results.addAll(getMethodsWithAnnotation(AtTransactional));
-		results.addAll(getMethodsWithAnnotation(AtJavaxTransactional));
-		return results;
+		return isAnnotatedInHierarchy(AtTransactional) || isAnnotatedInHierarchy(AtJavaxTransactional);
 	}
 
 	public boolean isAnnotatedInHierarchy(String anno) {

--- a/spring-native-configuration/src/main/java/org/springframework/TransactionalComponentProcessor.java
+++ b/spring-native-configuration/src/main/java/org/springframework/TransactionalComponentProcessor.java
@@ -16,16 +16,16 @@
 
 package org.springframework;
 
+import org.springframework.nativex.hint.ProxyBits;
+import org.springframework.nativex.type.ComponentProcessor;
+import org.springframework.nativex.type.NativeContext;
+import org.springframework.nativex.type.Type;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.springframework.nativex.hint.ProxyBits;
-import org.springframework.nativex.type.ComponentProcessor;
-import org.springframework.nativex.type.NativeContext;
-import org.springframework.nativex.type.Type;
 
 /**
  * Recognize spring.components that need transactional proxies and register them.
@@ -55,7 +55,7 @@ public class TransactionalComponentProcessor implements ComponentProcessor {
 		} else if (!type.isInterface()) {
 			// TODO is IS_STATIC always right here?
 			imageContext.addAotProxy(type.getDottedName(), Collections.emptyList(), ProxyBits.IS_STATIC);
-			imageContext.log(ValidatedComponentProcessor.class.getSimpleName() + ": creating proxy for this class: " + type.getDottedName());
+			imageContext.log(TransactionalComponentProcessor.class.getSimpleName() + ": creating proxy for this class: " + type.getDottedName());
 		}
 	}
 

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/TransactionalComponentProcessorTest.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/TransactionalComponentProcessorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional;
 
 import org.junit.Before;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/TransactionalComponentProcessorTest.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/TransactionalComponentProcessorTest.java
@@ -1,0 +1,167 @@
+package org.springframework.transactional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.TransactionalComponentProcessor;
+import org.springframework.nativex.type.TypeSystem;
+import org.springframework.nativex.util.NativeTestContext;
+import org.springframework.transactional.components.ComponentWithTransactionalInterface;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceAndExtraInterface;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceAndOtherMethod;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceOverProxyClass;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceOverProxyInterface;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceWithDefault;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceWithoutMethod;
+import org.springframework.transactional.components.ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod;
+import org.springframework.transactional.components.ComponentWithTransactionalMethod;
+import org.springframework.transactional.components.TransactionalComponent;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TransactionalComponentProcessorTest {
+
+    private NativeTestContext nativeContext = new NativeTestContext();
+    private TypeSystem typeSystem = nativeContext.getTypeSystem();
+    private TransactionalComponentProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new TransactionalComponentProcessor();
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterface() {
+        checkProxies(ComponentWithTransactionalInterface.class,
+                "org.springframework.transactional.components.TransactionalInterface",
+                Arrays.asList(
+                        "org.springframework.transactional.components.TransactionalInterface",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy"),
+                null);
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceAndExtraInterface() {
+        checkProxies(ComponentWithTransactionalInterfaceAndExtraInterface.class,
+                "org.springframework.transactional.components.TransactionalInterface",
+                Arrays.asList(
+                        "org.springframework.transactional.components.TransactionalInterface",
+                        "org.springframework.transactional.components.VoidInterface",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy"),
+                null);
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceAndOtherMethod() {
+        checkProxies(ComponentWithTransactionalInterfaceAndOtherMethod.class,
+                "org.springframework.transactional.components.TransactionalInterface",
+                Arrays.asList(
+                        "org.springframework.transactional.components.TransactionalInterface",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy"),
+                null);
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceOverSuperClass() {
+        checkProxies(ComponentWithTransactionalInterfaceOverProxyClass.class,
+                "org.springframework.transactional.components.TransactionalInterface",
+                Arrays.asList(
+                        "org.springframework.transactional.components.TransactionalInterface",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy"),
+                null);
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceOverSuperInterface() {
+        checkProxies(ComponentWithTransactionalInterfaceOverProxyInterface.class,
+                "org.springframework.transactional.components.ProxyInterface",
+                Arrays.asList(
+                        "org.springframework.transactional.components.ProxyInterface",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy"),
+                null);
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceWithoutMethod() {
+        checkProxies(ComponentWithTransactionalInterfaceWithoutMethod.class,
+                null,
+                null,
+                "org.springframework.transactional.components.ComponentWithTransactionalInterfaceWithoutMethod");
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod() {
+        checkProxies(ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.class,
+                null,
+                null,
+                "org.springframework.transactional.components.ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod");
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalInterfaceWithDefault() {
+        checkProxies(ComponentWithTransactionalInterfaceWithDefault.class,
+                "org.springframework.transactional.components.TransactionalInterfaceWithDefault",
+                Arrays.asList(
+                        "org.springframework.transactional.components.TransactionalInterfaceWithDefault",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy"),
+                null);
+    }
+
+    @Test
+    public void shouldDescribeProxiesForComponentWithTransactionalMethod() {
+        checkProxies(ComponentWithTransactionalMethod.class,
+                null,
+                null,
+                "org.springframework.transactional.components.ComponentWithTransactionalMethod");
+    }
+
+    @Test
+    public void shouldDescribeProxiesForTransactionalComponent() {
+        checkProxies(TransactionalComponent.class,
+                null,
+                null,
+                "org.springframework.transactional.components.TransactionalComponent");
+    }
+
+    private void checkProxies(Class component, String key, List<String> jdkProxies, String aotProxy) {
+        String componentType = typeSystem.resolve(component).getDottedName();
+
+        // handled
+        assertThat(processor.handle(nativeContext, componentType, Collections.emptyList())).isTrue();
+
+        // processed
+        processor.process(nativeContext, componentType, Collections.emptyList());
+
+        // and has correct proxies
+        if (key != null) {
+            assertThat(nativeContext.getProxyEntries()).isNotEmpty();
+            assertThat(nativeContext.getProxyEntries().get(key).get(0))
+                    .isEqualTo(jdkProxies);
+        } else {
+            assertThat(nativeContext.getProxyEntries()).isEmpty();
+        }
+        if (aotProxy == null) {
+            assertThat(nativeContext.getClassProxyEntries()).isEmpty();
+        } else {
+            assertThat(nativeContext.getClassProxyEntries().keySet()).isEqualTo(new HashSet<>(Arrays.asList(
+                    aotProxy)));
+        }
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterface.java
@@ -1,0 +1,14 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterface implements TransactionalInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndExtraInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndExtraInterface.java
@@ -1,0 +1,14 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceAndExtraInterface implements TransactionalInterface, VoidInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndExtraInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndExtraInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndOtherMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndOtherMethod.java
@@ -1,0 +1,18 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceAndOtherMethod implements TransactionalInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+    public void bar() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndOtherMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceAndOtherMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyClass.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyClass.java
@@ -1,0 +1,9 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceOverProxyClass extends ProxyClass {
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyClass.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyInterface.java
@@ -1,0 +1,14 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceOverProxyInterface implements ProxyInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceOverProxyInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithDefault.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithDefault.java
@@ -1,0 +1,9 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs jdk proxy
+@Component
+public class ComponentWithTransactionalInterfaceWithDefault implements TransactionalInterfaceWithDefault {
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithDefault.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithDefault.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethod.java
@@ -1,0 +1,9 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// no proxy needed
+@Component
+public class ComponentWithTransactionalInterfaceWithoutMethod implements TransactionalInterfaceWithoutMethod {
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod.java
@@ -1,0 +1,13 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+
+// needs aot proxy
+@Component
+public class ComponentWithTransactionalInterfaceWithoutMethodAndOtherMethod implements TransactionalInterfaceWithoutMethod {
+
+    public void bar() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalMethod.java
@@ -1,0 +1,15 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// aot proxy
+@Component
+public class ComponentWithTransactionalMethod {
+
+    @Transactional
+    public void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ComponentWithTransactionalMethod.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-// aot proxy
+// needs aot proxy
 @Component
 public class ComponentWithTransactionalMethod {
 

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyClass.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 public class ProxyClass implements TransactionalInterface {

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyClass.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyClass.java
@@ -1,0 +1,10 @@
+package org.springframework.transactional.components;
+
+public class ProxyClass implements TransactionalInterface {
+
+    @Override
+    public void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 public interface ProxyInterface extends TransactionalInterface {

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/ProxyInterface.java
@@ -1,0 +1,5 @@
+package org.springframework.transactional.components;
+
+public interface ProxyInterface extends TransactionalInterface {
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalComponent.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalComponent.java
@@ -1,0 +1,15 @@
+package org.springframework.transactional.components;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// needs aot proxy
+@Transactional
+@Component
+public class TransactionalComponent {
+
+    public void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalComponent.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalComponent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.stereotype.Component;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterface.java
@@ -1,0 +1,10 @@
+package org.springframework.transactional.components;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TransactionalInterface {
+
+    void foo();
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.transaction.annotation.Transactional;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithDefault.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithDefault.java
@@ -1,0 +1,12 @@
+package org.springframework.transactional.components;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TransactionalInterfaceWithDefault {
+
+    default void foo() {
+
+    }
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithDefault.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithDefault.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.transaction.annotation.Transactional;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithoutMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithoutMethod.java
@@ -1,0 +1,8 @@
+package org.springframework.transactional.components;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TransactionalInterfaceWithoutMethod {
+
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithoutMethod.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/TransactionalInterfaceWithoutMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 import org.springframework.transaction.annotation.Transactional;

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/VoidInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/VoidInterface.java
@@ -1,0 +1,4 @@
+package org.springframework.transactional.components;
+
+public interface VoidInterface {
+}

--- a/spring-native-configuration/src/test/java/org/springframework/transactional/components/VoidInterface.java
+++ b/spring-native-configuration/src/test/java/org/springframework/transactional/components/VoidInterface.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.transactional.components;
 
 public interface VoidInterface {


### PR DESCRIPTION
Improved transactional proxy detection for super classes and super interfaces so proxy hints are properly and automatically generated in these cases. This covers cases where `@Transactional` annotation is placed on interface implemented or its super interfaces or where the annotation is placed on super class. 