### PR TITLE
Fix Gradle task name in sample README

### DIFF
--- a/samples/commandlinerunner-gradle/README.md
+++ b/samples/commandlinerunner-gradle/README.md
@@ -2,6 +2,6 @@ Very basic Spring Boot project using a `CommandLineRunner` bean.
 
 To build and run the native application packaged in a lightweight container:
 ```
-./gradlew spring-boot:build-image
+./gradlew bootBuildImage
 docker-compose up
 ```


### PR DESCRIPTION
It was accidentally using Maven syntax.

@pivotal-cla This is an Obvious Fix