### PR TITLE
Fix maven plugin test-generate in 0.11.x

### DIFF
--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/TestGenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/TestGenerateMojo.java
@@ -72,12 +72,13 @@ public class TestGenerateMojo extends AbstractBootstrapMojo {
 		recreateGeneratedSourcesFolder(this.generatedTestSourcesDirectory);
 		Path sourcesPath = this.generatedTestSourcesDirectory.toPath().resolve(Paths.get("src", "test", "java"));
 		Path resourcesPath = this.generatedTestSourcesDirectory.toPath().resolve(Paths.get("src", "test", "resources"));
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 		try {
 			List<String> testClasspathElements = this.project.getTestClasspathElements();
 			Path classesPath = Paths.get(project.getBuild().getTestOutputDirectory());
 			BootstrapCodeGenerator generator = new BootstrapCodeGenerator(getAotOptions());
 			ApplicationStructure applicationStructure = new ApplicationStructure(sourcesPath, resourcesPath, resourceFolders,
-					classesPath, null, project.getRuntimeClasspathElements(), null);
+					classesPath, null, project.getRuntimeClasspathElements(), classLoader);
 			generator.generate(applicationStructure);
 			compileGeneratedTestSources(sourcesPath, testClasspathElements);
 			processGeneratedTestResources(resourcesPath, Paths.get(project.getBuild().getTestOutputDirectory()));

--- a/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/ContextBootstrapContributor.java
+++ b/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/ContextBootstrapContributor.java
@@ -66,13 +66,16 @@ public class ContextBootstrapContributor implements BootstrapContributor {
 		applicationContext.setEnvironment(new StandardEnvironment());
 
 		// TODO: auto-detect main class
-		ClassDescriptor mainClass = typeSystem.resolveClass(context.getMainClass());
-		logger.info("Detected main class: " + mainClass.getCanonicalClassName());
-		try {
-			applicationContext.registerBean(ClassUtils.forName(mainClass.getCanonicalClassName(), classLoader));
-		}
-		catch (ClassNotFoundException exc) {
-			 throw new IllegalStateException("Could not load main class" + mainClass.getCanonicalClassName(), exc);
+		String mainClassName = context.getMainClass();
+		if (mainClassName != null) {
+			ClassDescriptor mainClass = typeSystem.resolveClass(mainClassName);
+			logger.info("Detected main class: " + mainClass.getCanonicalClassName());
+			try {
+				applicationContext.registerBean(ClassUtils.forName(mainClass.getCanonicalClassName(), classLoader));
+			}
+			catch (ClassNotFoundException exc) {
+				throw new IllegalStateException("Could not load main class" + mainClass.getCanonicalClassName(), exc);
+			}
 		}
 		ConfigurableListableBeanFactory beanFactory = new BuildTimeBeanDefinitionsRegistrar(applicationContext).processBeanDefinitions();
 		ContextBootstrapGenerator bootstrapGenerator = new ContextBootstrapGenerator(classLoader);


### PR DESCRIPTION
When running `TestGenerateMojo` in `0.11.x` branch, it was failing on:
- `ClassNotFoundException` (e.g: `AnnotationConfigServletWebServerApplicationContext`)
- main class is `null`

For the `ClassNotFoundException`, changed to pass the thread context classloader from test mojo.

For the second one, `ContextBootstrapContributor` was not considering the case for `mainClass=null` and `Assert.notNul` fails down the line. So, added a logic to skip the mainClass registration when it is `null`.

This PR is for `0.11.x` branch.

cc @bclozel @snicoll @sdeleuze 
