### PR TITLE
Add a type hint for SimpleClientHttpRequestFactory

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactoryHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactoryHints.java
@@ -12,5 +12,8 @@ import org.springframework.nativex.type.NativeConfiguration;
 		okhttp3.OkHttpClient.class,
 		org.springframework.http.client.OkHttp3ClientHttpRequestFactory.class
 }))
+@NativeHint(trigger = org.springframework.http.client.SimpleClientHttpRequestFactory.class, types = @TypeHint(types = {
+		org.springframework.http.client.SimpleClientHttpRequestFactory.class
+}))
 public class ClientHttpRequestFactoryHints implements NativeConfiguration {
 }


### PR DESCRIPTION
The `connectTimeout` `readTimeout` and `bufferRequestBody` methods on
`RestTemplateBuilder` uses reflection to access underlying
`ClientHttpRequestFactory` implementation class.

Currently, type hints for `HttpComponentsClientHttpRequestFactory` and
`OkHttp3ClientHttpRequestFactory` exist, but the fallback request
factory, `SimpleClientHttpRequestFactory` hint doesn't exist.
Therefore, when `RestTemplate` doesn't detect either commons-client or
okhttp, it falls back to the `SimpleClientHttpRequestFactory` and the
reflective access fails to find the class.

This PR simply adds a hint to expose `SimpleClientHttpRequestFactory`,
so that above reflective methods on `RestTemplateBuilder` will have
access to it.

Fixes gh-954