### PR TITLE
Add ByteBuddy to the classpath of maven code generation process

### DIFF
--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
@@ -87,6 +87,8 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 					.ifPresent(artifact -> runtimeClasspathElements.add(1, artifact.getFile().getAbsolutePath()));
 			findJarFile(this.pluginArtifacts, "com.squareup", "javapoet")
 					.ifPresent(artifact -> runtimeClasspathElements.add(1, artifact.getFile().getAbsolutePath()));
+			findJarFile(this.pluginArtifacts, "net.bytebuddy", "byte-buddy")
+					.ifPresent(artifact -> runtimeClasspathElements.add(1, artifact.getFile().getAbsolutePath()));
 
 			if (getAotOptions().toMode().equals(Mode.NATIVE)) {
 				RunProcess runProcess = new RunProcess(Paths.get(this.project.getBuild().getDirectory()).toFile(), getJavaExecutable());


### PR DESCRIPTION
In `0.11.x` branch, when `GenerateMojo` invokes `BootstrapCodeGeneratorRunner`, it failed to find bytebuddy. (#968)

This is because when the `ProxyGenerator`, called by `ConfigurationContributor`, uses bytebuddy, the classloader needs to know the path to the bytebuddy.

In this changeset, similar to other dependencies, e.g. javapoet, finds bytebuddy jar file and adds it to the classpath to call `BootStrapCodeGenerator`.

