### PR TITLE
Add codeGenDebugPort property to debug Spring AOT plugins

### DIFF
--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
@@ -65,6 +65,8 @@ public class SpringAotGradlePlugin implements Plugin<Project> {
 
 	public static final String GENERATE_TEST_TASK_NAME = "generateTestAot";
 
+	public static final String CODE_GEN_DEBUG_PORT_PROPERTY = "codeGenDebugPort";
+
 
 	@Override
 	public void apply(final Project project) {

--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/dsl/SpringAotExtension.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/dsl/SpringAotExtension.java
@@ -51,6 +51,8 @@ public class SpringAotExtension {
 
 	private final Property<String> mainClass;
 
+	private final Property<Integer> codeGenDebugPort;
+
 	public SpringAotExtension(ObjectFactory objectFactory) {
 		this.mode = objectFactory.property(AotMode.class).convention(AotMode.NATIVE);
 		this.debugVerify = objectFactory.property(Boolean.class).convention(false);
@@ -64,6 +66,7 @@ public class SpringAotExtension {
 		this.buildTimePropertiesMatchIfMissing = objectFactory.property(Boolean.class).convention(true);
 		this.buildTimePropertiesChecks = objectFactory.property(String[].class).convention(new String[0]);
 		this.mainClass = objectFactory.property(String.class).convention((String)null);
+		this.codeGenDebugPort = objectFactory.property(Integer.class).convention((Integer) null);
 	}
 
 	/**
@@ -134,6 +137,13 @@ public class SpringAotExtension {
 	 */
 	public Property<String> getMainClass() {
 		return this.mainClass;
+	}
+
+	/**
+	 * Set remote debug port for code generation (not set by default).
+	 */
+	public Property<Integer> getCodeGenDebugPort() {
+		return this.codeGenDebugPort;
 	}
 
 	/**

--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotOptions.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotOptions.java
@@ -57,6 +57,8 @@ public class GenerateAotOptions implements Serializable {
 
 	private final Property<String[]> buildTimePropertiesChecks;
 
+	private final Property<Integer> codeGenDebugPort;
+
 	public GenerateAotOptions(SpringAotExtension extension) {
 		this.mode = extension.getMode().map(aotMode -> aotMode.getSlug());
 		this.debugVerify = extension.getDebugVerify();
@@ -70,6 +72,7 @@ public class GenerateAotOptions implements Serializable {
 		this.mainClass = extension.getMainClass();
 		this.buildTimePropertiesMatchIfMissing = extension.getBuildTimePropertiesMatchIfMissing();
 		this.buildTimePropertiesChecks = extension.getBuildTimePropertiesChecks();
+		this.codeGenDebugPort = extension.getCodeGenDebugPort();
 	}
 
 	@Input
@@ -121,6 +124,12 @@ public class GenerateAotOptions implements Serializable {
 	@Optional
 	public Property<String> getMainClass() {
 		return this.mainClass;
+	}
+
+	@Input
+	@Optional
+	public Property<Integer> getCodeGenDebugPort() {
+		return this.codeGenDebugPort;
 	}
 
 	@Input

--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/AbstractBootstrapMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/AbstractBootstrapMojo.java
@@ -108,6 +108,9 @@ abstract class AbstractBootstrapMojo extends AbstractMojo {
 	@Parameter(property = "spring.aot.mainClass")
 	protected String mainClass;
 
+	@Parameter(property = "spring.aot.codeGenDebugPort")
+	protected Integer codeGenDebugPort;
+
 	protected AotOptions getAotOptions() {
 		AotOptions aotOptions = new AotOptions();
 		aotOptions.setMode(mode);

--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
@@ -95,6 +95,11 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 				Runtime.getRuntime().addShutdownHook(new Thread(new RunProcessKiller(runProcess)));
 
 				List<String> args = new ArrayList<>();
+				// remote debug
+				if (this.codeGenDebugPort != null) {
+					args.add("-Xdebug");
+					args.add("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=" + this.codeGenDebugPort);
+				}
 				// plugin classpath
 				args.add("-cp");
 				args.add(asClasspathArgument(runtimeClasspathElements));


### PR DESCRIPTION
When this parameter is present, launch the code gen process with remote debug mode.

Sample command:
```
> mvn -Pnative spring-aot:generate@generate -Dspring.aot.codeGenDebugPort=9000
```