### PR TITLE
Simplify "codeGenDebugPort" implementation in gradle plugin

### DIFF
--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
@@ -65,7 +65,7 @@ public class SpringAotGradlePlugin implements Plugin<Project> {
 
 	public static final String GENERATE_TEST_TASK_NAME = "generateTestAot";
 
-	public static final String CODE_GEN_DEBUG_PORT_PROPERTY = "codeGenDebugPort";
+	private static final String CODE_GEN_DEBUG_PORT_PROPERTY = "codeGenDebugPort";
 
 
 	@Override
@@ -173,7 +173,25 @@ public class SpringAotGradlePlugin implements Plugin<Project> {
 		generate.setResourceInputDirectories(mainSourceSet.getResources());
 		generate.getSourcesOutputDirectory().set(aotSourcesDirectory);
 		generate.getResourcesOutputDirectory().set(aotResourcesDirectory);
+
+		Integer debugPort = getDebugPort(project);
+		if (debugPort != null) {
+			generate.setDebug(true);
+			generate.getDebugOptions().getPort().set(debugPort);
+		}
 		return generate;
+	}
+
+	private Integer getDebugPort(Project project) {
+		Object debugPortProperty = project.findProperty(CODE_GEN_DEBUG_PORT_PROPERTY);
+		if (debugPortProperty != null) {
+			try {
+				return Integer.parseInt(debugPortProperty.toString());
+			} catch (NumberFormatException exception) {
+				// ignore
+			}
+		}
+		return null;
 	}
 
 	private void configureAotTasks(Project project, SourceSet aotSourceSet, GenerateAotSources generateAotSources) {

--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/dsl/SpringAotExtension.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/dsl/SpringAotExtension.java
@@ -51,8 +51,6 @@ public class SpringAotExtension {
 
 	private final Property<String> mainClass;
 
-	private final Property<Integer> codeGenDebugPort;
-
 	public SpringAotExtension(ObjectFactory objectFactory) {
 		this.mode = objectFactory.property(AotMode.class).convention(AotMode.NATIVE);
 		this.debugVerify = objectFactory.property(Boolean.class).convention(false);
@@ -66,7 +64,6 @@ public class SpringAotExtension {
 		this.buildTimePropertiesMatchIfMissing = objectFactory.property(Boolean.class).convention(true);
 		this.buildTimePropertiesChecks = objectFactory.property(String[].class).convention(new String[0]);
 		this.mainClass = objectFactory.property(String.class).convention((String)null);
-		this.codeGenDebugPort = objectFactory.property(Integer.class).convention((Integer) null);
 	}
 
 	/**
@@ -137,13 +134,6 @@ public class SpringAotExtension {
 	 */
 	public Property<String> getMainClass() {
 		return this.mainClass;
-	}
-
-	/**
-	 * Set remote debug port for code generation (not set by default).
-	 */
-	public Property<Integer> getCodeGenDebugPort() {
-		return this.codeGenDebugPort;
 	}
 
 	/**

--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotOptions.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotOptions.java
@@ -57,8 +57,6 @@ public class GenerateAotOptions implements Serializable {
 
 	private final Property<String[]> buildTimePropertiesChecks;
 
-	private final Property<Integer> codeGenDebugPort;
-
 	public GenerateAotOptions(SpringAotExtension extension) {
 		this.mode = extension.getMode().map(aotMode -> aotMode.getSlug());
 		this.debugVerify = extension.getDebugVerify();
@@ -72,7 +70,6 @@ public class GenerateAotOptions implements Serializable {
 		this.mainClass = extension.getMainClass();
 		this.buildTimePropertiesMatchIfMissing = extension.getBuildTimePropertiesMatchIfMissing();
 		this.buildTimePropertiesChecks = extension.getBuildTimePropertiesChecks();
-		this.codeGenDebugPort = extension.getCodeGenDebugPort();
 	}
 
 	@Input
@@ -124,12 +121,6 @@ public class GenerateAotOptions implements Serializable {
 	@Optional
 	public Property<String> getMainClass() {
 		return this.mainClass;
-	}
-
-	@Input
-	@Optional
-	public Property<Integer> getCodeGenDebugPort() {
-		return this.codeGenDebugPort;
 	}
 
 	@Input

--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotSources.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/tasks/GenerateAotSources.java
@@ -19,8 +19,6 @@ package org.springframework.aot.gradle.tasks;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.aot.BootstrapCodeGenerator;
 import org.springframework.aot.context.bootstrap.BootstrapCodeGeneratorRunner;
-import org.springframework.aot.gradle.SpringAotGradlePlugin;
 import org.springframework.aot.gradle.dsl.SpringAotExtension;
 import org.springframework.util.StringUtils;
 
@@ -69,7 +66,6 @@ public class GenerateAotSources extends JavaExec {
 		this.aotOptions = new GenerateAotOptions(getProject().getExtensions().findByType(SpringAotExtension.class));
 		setMain(BootstrapCodeGeneratorRunner.class.getCanonicalName());
 		getArgumentProviders().add(new BootstrapGeneratorArgumentProvider());
-		getJvmArgumentProviders().add(new BootstrapGeneratorJvmArgumentProvider());
 	}
 
 	@InputFiles
@@ -143,34 +139,6 @@ public class GenerateAotSources extends JavaExec {
 			List<String> paths = files.stream().map(File::toPath).map(Path::toString).collect(Collectors.toList());
 			return StringUtils.collectionToDelimitedString(paths, File.pathSeparator);
 		}
-	}
-
-	private class BootstrapGeneratorJvmArgumentProvider implements CommandLineArgumentProvider {
-
-		@Override
-		public Iterable<String> asArguments() {
-			Integer debugPort = getDebugPort();
-			if (debugPort != null) {
-				return Arrays.asList("-Xdebug",
-						     "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address="
-						     + debugPort);
-			}
-			return Collections.emptyList();
-		}
-
-		private Integer getDebugPort() {
-			Object debugPortProperty =
-					getProject().findProperty(SpringAotGradlePlugin.CODE_GEN_DEBUG_PORT_PROPERTY);
-			if (debugPortProperty != null) {
-				try {
-					return Integer.parseInt(debugPortProperty.toString());
-				} catch (NumberFormatException exception) {
-					// ignore
-				}
-			}
-			return GenerateAotSources.this.aotOptions.getCodeGenDebugPort().getOrNull();
-		}
-
 	}
 
 }

--- a/spring-native-docs/src/main/asciidoc/spring-aot.adoc
+++ b/spring-native-docs/src/main/asciidoc/spring-aot.adoc
@@ -216,6 +216,21 @@ about specifying properties that activate configurations. (This is a work-in-pro
 by a comma separated list of prefixes to explicitly include or exclude (for example `default-include-all,!spring.dont.include.these.,!or.these` or `default-exclude-all,spring.include.this.one.though.,and.this.one`). When considering a property the
 longest matching prefix in this setting will apply (in cases where a property matches multiple prefixes).
 
+==== Debugging the source generation
+
+The Spring AOT plugins spawn a new process to perform the source generation. To remote debug this process, set the `codeGenDebugPort` parameter in the command line argument; then, the source generation process launches with a listener accepting a remote debugger on the specified port.
+
+[source,bash,role="primary"]
+.Maven
+----
+$ mvn -Pnative spring-aot:generate@generate -Dspring.aot.codeGenDebugPort=9000
+----
+[source,bash,role="secondary"]
+.Gradle
+----
+$ gradle generateAot -PcodeGenDebugPort=9000
+----
+
 
 [[spring-aot-modes]]
 === AOT Modes


### PR DESCRIPTION
Previously, the `codeGenDebugPort` implementation in gradle plugin was
not effectively using the `JavaExec` infrastructure.  This commit
updates to use the debug options from `JavaExec` to configure the
remote debugging.

For code simplification, remove the `springAot` DSL support and only
take `codeGenDebugPort` project property. This is because, in most
cases, remote debug is specified in the command line.

Also, adding documentation about `codeGenDebugPort` parameter.