### PR TITLE
gh-950 use Set instead of List in proxy descriptors

### DIFF
--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/AotProxyDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/AotProxyDescriptor.java
@@ -16,8 +16,9 @@
 
 package org.springframework.nativex.domain.proxies;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 
 import org.springframework.aop.framework.BuildTimeProxyDescriptor;
 import org.springframework.nativex.hint.ProxyBits;
@@ -32,7 +33,7 @@ public class AotProxyDescriptor extends JdkProxyDescriptor {
 
 	private final int proxyFeatures;
 	
-	public AotProxyDescriptor(String targetClassName, List<String> interfaceNames, int proxyFeatures) {
+	public AotProxyDescriptor(String targetClassName, Collection<String> interfaceNames, int proxyFeatures) {
 		super(interfaceNames);
 		this.targetClassName = targetClassName;
 		this.proxyFeatures = proxyFeatures;
@@ -42,11 +43,11 @@ public class AotProxyDescriptor extends JdkProxyDescriptor {
 		return targetClassName;
 	}
 
-	public List<String> getInterfaceTypes() {
+	public Collection<String> getInterfaceTypes() {
 		return types;
 	}
 
-	public List<String> getTypes() {
+	public Collection<String> getTypes() {
 		throw new IllegalStateException();
 	}
 	
@@ -96,6 +97,6 @@ public class AotProxyDescriptor extends JdkProxyDescriptor {
 	}
 
 	public BuildTimeProxyDescriptor asCPDescriptor() {
-		return new BuildTimeProxyDescriptor(targetClassName, types, proxyFeatures);
+		return new BuildTimeProxyDescriptor(targetClassName, new ArrayList<>(types), proxyFeatures);
 	}
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/JdkProxyDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/JdkProxyDescriptor.java
@@ -16,8 +16,9 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Describes a proxy via a set of types it should implement.
@@ -26,13 +27,13 @@ import java.util.List;
  */
 public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 
-	protected List<String> types; // e.g. java.io.Serializable
+	protected Set<String> types; // e.g. java.io.Serializable
 
 	JdkProxyDescriptor() {
 	}
 
-	public JdkProxyDescriptor(List<String> types) {
-		this.types = new ArrayList<>(types);
+	public JdkProxyDescriptor(Collection<String> types) {
+		this.types = new HashSet<>(types);
 	}
 
 	@Override
@@ -84,36 +85,29 @@ public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 
 	@Override
 	public int compareTo(JdkProxyDescriptor o) {
-		List<String> l = this.types;
-		List<String> r = o.types;
+		Set<String> l = this.types;
+		Set<String> r = o.types;
 		if (l.size() != r.size()) {
 			return l.size() - r.size();
 		}
-		for (int i = 0; i < l.size(); i++) {
-			int cmpTo = l.get(i).compareTo(r.get(i));
-			if (cmpTo != 0) {
-				return cmpTo;
-			}
-		}
-		return 0; // equal!
+		return l.containsAll(r) ? 0 : 1; // equal!
 	}
 
-	public static JdkProxyDescriptor of(List<String> interfaces) {
+	public static JdkProxyDescriptor of(Collection<String> interfaces) {
 		JdkProxyDescriptor pd = new JdkProxyDescriptor();
 		pd.setInterfaces(interfaces);
 		return pd;
 	}
 
-	public void setInterfaces(List<String> interfaces) {
-		this.types = new ArrayList<>();
-		this.types.addAll(interfaces);
+	public void setInterfaces(Collection<String> interfaces) {
+		this.types = new HashSet<>(interfaces);
 	}
 
 	public boolean containsInterface(String intface) {
 		return types.contains(intface);
 	}
 
-	public List<String> getTypes() {
+	public Collection<String> getTypes() {
 		return types;
 	}
 

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptor.java
@@ -16,28 +16,29 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
- * https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md
+ * https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Reflection.md
  * 
  * @author Andy Clement
  */
 public class ProxiesDescriptor {
 
-	private final List<JdkProxyDescriptor> proxyDescriptors;
+	private final Set<JdkProxyDescriptor> proxyDescriptors;
 
 	public ProxiesDescriptor() {
-		this.proxyDescriptors = new ArrayList<>();
+		this.proxyDescriptors = new HashSet<>();
 	}
 
 	public ProxiesDescriptor(ProxiesDescriptor metadata) {
-		this.proxyDescriptors = new ArrayList<>(metadata.proxyDescriptors);
+		this.proxyDescriptors = new HashSet<>(metadata.proxyDescriptors);
 	}
 
-	public List<JdkProxyDescriptor> getProxyDescriptors() {
+	public Collection<JdkProxyDescriptor> getProxyDescriptors() {
 		return this.proxyDescriptors;
 	}
 
@@ -75,7 +76,7 @@ public class ProxiesDescriptor {
 		}
 	}
 
-	public void consume(Consumer<List<String>> consumer) {
+	public void consume(Consumer<Collection<String>> consumer) {
 		proxyDescriptors.stream().forEach(pd -> consumer.accept(pd.getTypes()));
 	}
 

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonConverter.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonConverter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.springframework.nativex.json.JSONArray;
 
@@ -37,7 +37,7 @@ class ProxiesDescriptorJsonConverter {
 
 	public JSONArray toJsonArray(JdkProxyDescriptor pd) throws Exception {
 		JSONArray jsonArray = new JSONArray();
-		List<String> interfaces = pd.getTypes();
+		Collection<String> interfaces = pd.getTypes();
 		for (String intface: interfaces) {
 			jsonArray.put(intface);
 		}

--- a/spring-aot/src/main/java/org/springframework/nativex/support/ConfigurationCollector.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/ConfigurationCollector.java
@@ -17,9 +17,6 @@
 package org.springframework.nativex.support;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,8 +35,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.nativex.AotOptions;
 import org.springframework.nativex.domain.init.InitializationDescriptor;
 import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
-import org.springframework.nativex.domain.proxies.ProxiesDescriptor;
 import org.springframework.nativex.domain.proxies.JdkProxyDescriptor;
+import org.springframework.nativex.domain.proxies.ProxiesDescriptor;
 import org.springframework.nativex.domain.reflect.ClassDescriptor;
 import org.springframework.nativex.domain.reflect.FieldDescriptor;
 import org.springframework.nativex.domain.reflect.MethodDescriptor;
@@ -146,9 +143,8 @@ public class ConfigurationCollector {
 		this.ts = ts;
 	}
 
-	private boolean checkTypes(List<String> types, Predicate<Type> test) {
-		for (int i = 0; i < types.size(); i++) {
-			String className = types.get(i);
+	private boolean checkTypes(Collection<String> types, Predicate<Type> test) {
+		for (String className : types) {
 			Type clazz = ts.resolveDotted(className, true);
 			if (!test.test(clazz)) {
 				return false;
@@ -157,7 +153,7 @@ public class ConfigurationCollector {
 		return true;
 	}
 
-	public boolean addProxy(List<String> interfaceNames, boolean verify) {
+	public boolean addProxy(Collection<String> interfaceNames, boolean verify) {
 		if (verify) {
 			if (!checkTypes(interfaceNames, t -> t!=null && t.isInterface())) {
 				return false;
@@ -185,13 +181,6 @@ public class ConfigurationCollector {
 			return null;
 		} else {
 			return Arrays.copyOfRange(array, 1, array.length);
-		}
-	}
-	
-	private void writeNativeImageProperties(File file) throws IOException {
-		String content = getNativeImagePropertiesContent();
-		try (FileOutputStream fos = new FileOutputStream(file)) {
-			fos.write(content.getBytes());
 		}
 	}
 	
@@ -304,7 +293,6 @@ public class ConfigurationCollector {
 			if (areMembersSpecified(classDescriptor)) {
 				if (!verifyMembers(classDescriptor)) {
 					logger.debug("Stripped down to a base class descriptor for "+classDescriptor.getName());
-					Set<Flag> existingFlags = classDescriptor.getFlags();
 					classDescriptor = ClassDescriptor.of(classDescriptor.getName());
 					// TODO should set some flags here?
 					anyFailed=true;
@@ -345,7 +333,6 @@ public class ConfigurationCollector {
 		}
 		if (areMembersSpecified(classDescriptor)) {
 			if (!verifyMembers(classDescriptor)) {
-				Set<Flag> existingFlags = classDescriptor.getFlags();
 				classDescriptor = ClassDescriptor.of(classDescriptor.getName());
 				// TODO should set some flags here? e.g	classDescriptor.setFlags(existingFlags);
 			}
@@ -359,7 +346,6 @@ public class ConfigurationCollector {
 		}
 		if (areMembersSpecified(classDescriptor)) {
 			if (!verifyMembers(classDescriptor)) {
-				Set<Flag> existingFlags = classDescriptor.getFlags();
 				classDescriptor = ClassDescriptor.of(classDescriptor.getName());
 				// TODO should set some flags here? e.g	classDescriptor.setFlags(existingFlags);
 			}

--- a/spring-aot/src/main/java/org/springframework/nativex/support/DynamicProxiesHandler.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/DynamicProxiesHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.nativex.support;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.domain.proxies.JdkProxyDescriptor;
@@ -39,12 +39,12 @@ public class DynamicProxiesHandler extends Handler {
 		}
 	}
 	
-	public boolean addClassProxy(String targetClassName, List<String> interfaceNames, int proxyFeatures) {
+	public boolean addClassProxy(String targetClassName, Collection<String> interfaceNames, int proxyFeatures) {
 		AotProxyDescriptor cpd = new AotProxyDescriptor(targetClassName, interfaceNames, proxyFeatures);
 		return collector.addClassProxy(cpd, true);
 	}
 
-	public boolean addProxy(List<String> interfaceNames) {
+	public boolean addProxy(Collection<String> interfaceNames) {
 		return collector.addProxy(interfaceNames, true);
 	}
 }

--- a/spring-aot/src/test/java/org/springframework/nativex/DescriptorTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/DescriptorTests.java
@@ -90,8 +90,8 @@ public class DescriptorTests {
 		ProxiesDescriptor pd2 = ProxiesDescriptor.fromJSON(json);
 		assertThat(pd.toString()).isEqualTo(pd2.toString());
 		assertThat(d.containsInterface("java.io.Serializable")).isTrue();
-		assertThat(d.compareTo(pd2.getProxyDescriptors().get(0))).isEqualTo(0);
-		assertThat(d.equals(pd2.getProxyDescriptors().get(0))).isTrue();
+		assertThat(d.compareTo(pd2.getProxyDescriptors().iterator().next())).isEqualTo(0);
+		assertThat(d.equals(pd2.getProxyDescriptors().iterator().next())).isTrue();
 	}
 
 	@Test

--- a/spring-aot/src/test/java/org/springframework/nativex/HintTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/HintTests.java
@@ -260,7 +260,7 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.String");
-		assertThat(cpd.getInterfaceTypes().get(0)).isEqualTo("java.io.Serializable");
+		assertThat(cpd.getInterfaceTypes().iterator().next()).isEqualTo("java.io.Serializable");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 
@@ -281,7 +281,7 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.String");
-		assertThat(cpd.getInterfaceTypes().get(0)).isEqualTo("java.util.List");
+		assertThat(cpd.getInterfaceTypes().iterator().next()).isEqualTo("java.util.List");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 
@@ -312,12 +312,12 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.Integer");
-		assertThat(cpd.getInterfaceTypes().get(0)).isEqualTo("java.util.List");
+		assertThat(cpd.getInterfaceTypes().iterator().next()).isEqualTo("java.util.List");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd2 = (AotProxyDescriptor)proxyDescriptors.get(1);
 		assertThat(cpd2.getTargetClassType()).isEqualTo("java.lang.Number");
-		assertThat(cpd2.getInterfaceTypes().get(0)).isEqualTo("java.util.List");
+		assertThat(cpd2.getInterfaceTypes().iterator().next()).isEqualTo("java.util.List");
 		assertThat(cpd2.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 	

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
@@ -56,7 +56,7 @@ public class HintDeclarationAssert extends AbstractAssert<HintDeclarationAssert,
 	public HintDeclarationAssert containsProxyFor(Class<?> type) {
 
 		if (!actual.getProxyDescriptors().stream().map(JdkProxyDescriptor::getTypes)
-				.anyMatch(types -> type.getName().equals(types.get(0)))) {
+				.anyMatch(types -> type.getName().equals(types.iterator().next()))) {
 
 			failWithMessage("Expected HintDeclaration to contain proxy config for %s but was not in %s",
 					type.getName(), actual.getProxyDescriptors());


### PR DESCRIPTION
On Windows, it happens that `proxy-config.json` is generated with "repeated interface" when building native docker images (`spring-boot:build-image` with `<BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>`)

Has spotted by @arielcarrera, this happens when a class is annotated with two annotations that require a proxy like @Validated and @ConfigurationProperties (in my case, it was a `@Controller` annotated with `@RestController`, `@RequiredArgsConstructor` and `@PreAuthorize`).

As I haven't unerstood the value of ordered collections inside proxy descriptors, I propose here to replace `List` by `Set` for private members and `Collection` in methods signatures.

This should fix https://github.com/spring-projects-experimental/spring-native/issues/950