### PR TITLE
Fix to repeated interface error

### DIFF
--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/AotProxyDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/AotProxyDescriptor.java
@@ -18,7 +18,7 @@ package org.springframework.nativex.domain.proxies;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.SortedSet;
+import java.util.Set;
 
 import org.springframework.aop.framework.BuildTimeProxyDescriptor;
 import org.springframework.nativex.hint.ProxyBits;
@@ -44,11 +44,11 @@ public class AotProxyDescriptor extends JdkProxyDescriptor {
 		return targetClassName;
 	}
 
-	public SortedSet<String> getInterfaceTypes() {
+	public Set<String> getInterfaceTypes() {
 		return types;
 	}
 
-	public SortedSet<String> getTypes() {
+	public Set<String> getTypes() {
 		throw new IllegalStateException();
 	}
 	

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/AotProxyDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/AotProxyDescriptor.java
@@ -17,7 +17,8 @@
 package org.springframework.nativex.domain.proxies;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
+import java.util.SortedSet;
 
 import org.springframework.aop.framework.BuildTimeProxyDescriptor;
 import org.springframework.nativex.hint.ProxyBits;
@@ -25,6 +26,7 @@ import org.springframework.nativex.hint.ProxyBits;
 /**
  * 
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class AotProxyDescriptor extends JdkProxyDescriptor {
 	
@@ -32,7 +34,7 @@ public class AotProxyDescriptor extends JdkProxyDescriptor {
 
 	private final int proxyFeatures;
 	
-	public AotProxyDescriptor(String targetClassName, List<String> interfaceNames, int proxyFeatures) {
+	public AotProxyDescriptor(String targetClassName, Collection<String> interfaceNames, int proxyFeatures) {
 		super(interfaceNames);
 		this.targetClassName = targetClassName;
 		this.proxyFeatures = proxyFeatures;
@@ -42,11 +44,11 @@ public class AotProxyDescriptor extends JdkProxyDescriptor {
 		return targetClassName;
 	}
 
-	public List<String> getInterfaceTypes() {
+	public SortedSet<String> getInterfaceTypes() {
 		return types;
 	}
 
-	public List<String> getTypes() {
+	public SortedSet<String> getTypes() {
 		throw new IllegalStateException();
 	}
 	

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/JdkProxyDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/JdkProxyDescriptor.java
@@ -17,8 +17,9 @@
 package org.springframework.nativex.domain.proxies;
 
 import java.util.Collection;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Describes a proxy via a set of types it should implement.
@@ -28,13 +29,13 @@ import java.util.TreeSet;
  */
 public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 
-	protected SortedSet<String> types; // e.g. java.io.Serializable
+	protected Set<String> types; // e.g. java.io.Serializable
 
 	JdkProxyDescriptor() {
 	}
 
 	public JdkProxyDescriptor(Collection<String> types) {
-		this.types = new TreeSet<>(types);
+		this.types = new LinkedHashSet<>(types);
 	}
 
 	@Override
@@ -86,12 +87,21 @@ public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 
 	@Override
 	public int compareTo(JdkProxyDescriptor o) {
-		SortedSet<String> l = this.types;
-		SortedSet<String> r = o.types;
+		Set<String> l = this.types;
+		Set<String> r = o.types;
 		if (l.size() != r.size()) {
 			return l.size() - r.size();
 		}
-		return l.containsAll(r) ? 0 : 1; // equal!
+		if (l.isEmpty()) return 0;
+		
+		Iterator<String> iterator1 = l.iterator();
+		Iterator<String> iterator2 = r.iterator();
+		while (iterator1.hasNext() && iterator2.hasNext()) {
+			int value = iterator1.next().compareTo(iterator2.next());
+			if (value != 0)
+				return value;
+		}
+		return 0; // equal!
 	}
 
 	public static JdkProxyDescriptor of(Collection<String> interfaces) {
@@ -101,15 +111,14 @@ public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 	}
 
 	public void setInterfaces(Collection<String> interfaces) {
-		this.types = new TreeSet<>();
-		this.types.addAll(interfaces);
+		this.types = new LinkedHashSet<>(interfaces);
 	}
 
 	public boolean containsInterface(String intface) {
 		return types.contains(intface);
 	}
 
-	public SortedSet<String> getTypes() {
+	public Set<String> getTypes() {
 		return types;
 	}
 

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/JdkProxyDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/JdkProxyDescriptor.java
@@ -16,23 +16,25 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Describes a proxy via a set of types it should implement.
  *
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 
-	protected List<String> types; // e.g. java.io.Serializable
+	protected SortedSet<String> types; // e.g. java.io.Serializable
 
 	JdkProxyDescriptor() {
 	}
 
-	public JdkProxyDescriptor(List<String> types) {
-		this.types = new ArrayList<>(types);
+	public JdkProxyDescriptor(Collection<String> types) {
+		this.types = new TreeSet<>(types);
 	}
 
 	@Override
@@ -84,28 +86,22 @@ public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 
 	@Override
 	public int compareTo(JdkProxyDescriptor o) {
-		List<String> l = this.types;
-		List<String> r = o.types;
+		SortedSet<String> l = this.types;
+		SortedSet<String> r = o.types;
 		if (l.size() != r.size()) {
 			return l.size() - r.size();
 		}
-		for (int i = 0; i < l.size(); i++) {
-			int cmpTo = l.get(i).compareTo(r.get(i));
-			if (cmpTo != 0) {
-				return cmpTo;
-			}
-		}
-		return 0; // equal!
+		return l.containsAll(r) ? 0 : 1; // equal!
 	}
 
-	public static JdkProxyDescriptor of(List<String> interfaces) {
+	public static JdkProxyDescriptor of(Collection<String> interfaces) {
 		JdkProxyDescriptor pd = new JdkProxyDescriptor();
 		pd.setInterfaces(interfaces);
 		return pd;
 	}
 
-	public void setInterfaces(List<String> interfaces) {
-		this.types = new ArrayList<>();
+	public void setInterfaces(Collection<String> interfaces) {
+		this.types = new TreeSet<>();
 		this.types.addAll(interfaces);
 	}
 
@@ -113,7 +109,7 @@ public class JdkProxyDescriptor implements Comparable<JdkProxyDescriptor> {
 		return types.contains(intface);
 	}
 
-	public List<String> getTypes() {
+	public SortedSet<String> getTypes() {
 		return types;
 	}
 

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptor.java
@@ -16,28 +16,30 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
 /**
  * https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md
  * 
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class ProxiesDescriptor {
 
-	private final List<JdkProxyDescriptor> proxyDescriptors;
+	private final SortedSet<JdkProxyDescriptor> proxyDescriptors;
 
 	public ProxiesDescriptor() {
-		this.proxyDescriptors = new ArrayList<>();
+		this.proxyDescriptors = new TreeSet<>();
 	}
 
 	public ProxiesDescriptor(ProxiesDescriptor metadata) {
-		this.proxyDescriptors = new ArrayList<>(metadata.proxyDescriptors);
+		this.proxyDescriptors = new TreeSet<>(metadata.proxyDescriptors);
 	}
 
-	public List<JdkProxyDescriptor> getProxyDescriptors() {
+	public SortedSet<JdkProxyDescriptor> getProxyDescriptors() {
 		return this.proxyDescriptors;
 	}
 
@@ -75,7 +77,7 @@ public class ProxiesDescriptor {
 		}
 	}
 
-	public void consume(Consumer<List<String>> consumer) {
+	public void consume(Consumer<Collection<String>> consumer) {
 		proxyDescriptors.stream().forEach(pd -> consumer.accept(pd.getTypes()));
 	}
 

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptor.java
@@ -17,8 +17,8 @@
 package org.springframework.nativex.domain.proxies;
 
 import java.util.Collection;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -29,17 +29,17 @@ import java.util.function.Consumer;
  */
 public class ProxiesDescriptor {
 
-	private final SortedSet<JdkProxyDescriptor> proxyDescriptors;
+	private final Set<JdkProxyDescriptor> proxyDescriptors;
 
 	public ProxiesDescriptor() {
-		this.proxyDescriptors = new TreeSet<>();
+		this.proxyDescriptors = new LinkedHashSet<>();
 	}
 
 	public ProxiesDescriptor(ProxiesDescriptor metadata) {
-		this.proxyDescriptors = new TreeSet<>(metadata.proxyDescriptors);
+		this.proxyDescriptors = new LinkedHashSet<>(metadata.proxyDescriptors);
 	}
 
-	public SortedSet<JdkProxyDescriptor> getProxyDescriptors() {
+	public Set<JdkProxyDescriptor> getProxyDescriptors() {
 		return this.proxyDescriptors;
 	}
 

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonConverter.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonConverter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.SortedSet;
+import java.util.Set;
 
 import org.springframework.nativex.json.JSONArray;
 
@@ -38,7 +38,7 @@ class ProxiesDescriptorJsonConverter {
 
 	public JSONArray toJsonArray(JdkProxyDescriptor pd) throws Exception {
 		JSONArray jsonArray = new JSONArray();
-		SortedSet<String> interfaces = pd.getTypes();
+		Set<String> interfaces = pd.getTypes();
 		for (String intface: interfaces) {
 			jsonArray.put(intface);
 		}

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonConverter.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonConverter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.nativex.domain.proxies;
 
-import java.util.List;
+import java.util.SortedSet;
 
 import org.springframework.nativex.json.JSONArray;
 
@@ -24,6 +24,7 @@ import org.springframework.nativex.json.JSONArray;
  * Converter to change reflection descriptor objects into JSON objects
  *
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 class ProxiesDescriptorJsonConverter {
 
@@ -37,7 +38,7 @@ class ProxiesDescriptorJsonConverter {
 
 	public JSONArray toJsonArray(JdkProxyDescriptor pd) throws Exception {
 		JSONArray jsonArray = new JSONArray();
-		List<String> interfaces = pd.getTypes();
+		SortedSet<String> interfaces = pd.getTypes();
 		for (String intface: interfaces) {
 			jsonArray.put(intface);
 		}

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonMarshaller.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonMarshaller.java
@@ -23,8 +23,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.springframework.nativex.json.JSONArray;
 
@@ -32,6 +32,7 @@ import org.springframework.nativex.json.JSONArray;
  * Marshaller to write {@link ProxiesDescriptor} as JSON.
  *
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class ProxiesDescriptorJsonMarshaller {
 
@@ -90,7 +91,7 @@ public class ProxiesDescriptorJsonMarshaller {
 	
 	private static JdkProxyDescriptor toProxyDescriptor(JSONArray array) throws Exception {
 		JdkProxyDescriptor pd = new JdkProxyDescriptor();
-		List<String> interfaces = new ArrayList<>();
+		Set<String> interfaces = new HashSet<>();
 		for (int i=0;i<array.length();i++) {
 			interfaces.add(array.getString(i));
 		}

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonMarshaller.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/proxies/ProxiesDescriptorJsonMarshaller.java
@@ -23,8 +23,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.springframework.nativex.json.JSONArray;
 
@@ -91,7 +91,7 @@ public class ProxiesDescriptorJsonMarshaller {
 	
 	private static JdkProxyDescriptor toProxyDescriptor(JSONArray array) throws Exception {
 		JdkProxyDescriptor pd = new JdkProxyDescriptor();
-		Set<String> interfaces = new HashSet<>();
+		Collection<String> interfaces = new ArrayList<>();
 		for (int i=0;i<array.length();i++) {
 			interfaces.add(array.getString(i));
 		}

--- a/spring-aot/src/main/java/org/springframework/nativex/support/ConfigurationCollector.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/ConfigurationCollector.java
@@ -54,6 +54,7 @@ import org.springframework.nativex.type.TypeSystem;
  * Centralized collector of all computed configuration, can be used to produce JSON files.
  * 
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class ConfigurationCollector {
 
@@ -146,9 +147,8 @@ public class ConfigurationCollector {
 		this.ts = ts;
 	}
 
-	private boolean checkTypes(List<String> types, Predicate<Type> test) {
-		for (int i = 0; i < types.size(); i++) {
-			String className = types.get(i);
+	private boolean checkTypes(Collection<String> types, Predicate<Type> test) {
+		for (String className : types) {
 			Type clazz = ts.resolveDotted(className, true);
 			if (!test.test(clazz)) {
 				return false;
@@ -157,7 +157,7 @@ public class ConfigurationCollector {
 		return true;
 	}
 
-	public boolean addProxy(List<String> interfaceNames, boolean verify) {
+	public boolean addProxy(Collection<String> interfaceNames, boolean verify) {
 		if (verify) {
 			if (!checkTypes(interfaceNames, t -> t!=null && t.isInterface())) {
 				return false;

--- a/spring-aot/src/main/java/org/springframework/nativex/support/DynamicProxiesHandler.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/DynamicProxiesHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.nativex.support;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.springframework.nativex.domain.proxies.AotProxyDescriptor;
 import org.springframework.nativex.domain.proxies.JdkProxyDescriptor;
@@ -24,6 +24,7 @@ import org.springframework.nativex.domain.proxies.JdkProxyDescriptor;
 /**
  * 
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class DynamicProxiesHandler extends Handler {
 
@@ -39,12 +40,12 @@ public class DynamicProxiesHandler extends Handler {
 		}
 	}
 	
-	public boolean addClassProxy(String targetClassName, List<String> interfaceNames, int proxyFeatures) {
+	public boolean addClassProxy(String targetClassName, Collection<String> interfaceNames, int proxyFeatures) {
 		AotProxyDescriptor cpd = new AotProxyDescriptor(targetClassName, interfaceNames, proxyFeatures);
 		return collector.addClassProxy(cpd, true);
 	}
 
-	public boolean addProxy(List<String> interfaceNames) {
+	public boolean addProxy(Collection<String> interfaceNames) {
 		return collector.addProxy(interfaceNames, true);
 	}
 }

--- a/spring-aot/src/test/java/org/springframework/nativex/DescriptorTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/DescriptorTests.java
@@ -90,8 +90,8 @@ public class DescriptorTests {
 		ProxiesDescriptor pd2 = ProxiesDescriptor.fromJSON(json);
 		assertThat(pd.toString()).isEqualTo(pd2.toString());
 		assertThat(d.containsInterface("java.io.Serializable")).isTrue();
-		assertThat(d.compareTo(pd2.getProxyDescriptors().get(0))).isEqualTo(0);
-		assertThat(d.equals(pd2.getProxyDescriptors().get(0))).isTrue();
+		assertThat(d.compareTo(pd2.getProxyDescriptors().first())).isEqualTo(0);
+		assertThat(d.equals(pd2.getProxyDescriptors().first())).isTrue();
 	}
 
 	@Test

--- a/spring-aot/src/test/java/org/springframework/nativex/DescriptorTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/DescriptorTests.java
@@ -90,8 +90,8 @@ public class DescriptorTests {
 		ProxiesDescriptor pd2 = ProxiesDescriptor.fromJSON(json);
 		assertThat(pd.toString()).isEqualTo(pd2.toString());
 		assertThat(d.containsInterface("java.io.Serializable")).isTrue();
-		assertThat(d.compareTo(pd2.getProxyDescriptors().first())).isEqualTo(0);
-		assertThat(d.equals(pd2.getProxyDescriptors().first())).isTrue();
+		assertThat(d.compareTo(pd2.getProxyDescriptors().iterator().next())).isEqualTo(0);
+		assertThat(d.equals(pd2.getProxyDescriptors().iterator().next())).isTrue();
 	}
 
 	@Test

--- a/spring-aot/src/test/java/org/springframework/nativex/HintTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/HintTests.java
@@ -115,8 +115,8 @@ public class HintTests {
 		List<JdkProxyDescriptor> proxies= hint.getProxyDescriptors();
 		assertEquals(1,proxies.size());
 		String[] types = proxies.get(0).getTypes().toArray(new String[] {}); 
-		assertEquals("java.lang.Integer",types[0]);
-		assertEquals("java.lang.String",types[1]);
+		assertEquals("java.lang.String",types[0]);
+		assertEquals("java.lang.Integer",types[1]);
 	}
 
 	@NativeHint(jdkProxies = { @JdkProxyHint(types = { String.class,Integer.class }) })
@@ -260,7 +260,7 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.String");
-		assertThat(cpd.getInterfaceTypes().first()).isEqualTo("java.io.Serializable");
+		assertThat(cpd.getInterfaceTypes().iterator().next()).isEqualTo("java.io.Serializable");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 
@@ -281,7 +281,7 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.String");
-		assertThat(cpd.getInterfaceTypes().first()).isEqualTo("java.util.List");
+		assertThat(cpd.getInterfaceTypes().iterator().next()).isEqualTo("java.util.List");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 
@@ -312,12 +312,12 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.Integer");
-		assertThat(cpd.getInterfaceTypes().first()).isEqualTo("java.util.List");
+		assertThat(cpd.getInterfaceTypes().iterator().next()).isEqualTo("java.util.List");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd2 = (AotProxyDescriptor)proxyDescriptors.get(1);
 		assertThat(cpd2.getTargetClassType()).isEqualTo("java.lang.Number");
-		assertThat(cpd2.getInterfaceTypes().first()).isEqualTo("java.util.List");
+		assertThat(cpd2.getInterfaceTypes().iterator().next()).isEqualTo("java.util.List");
 		assertThat(cpd2.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 	

--- a/spring-aot/src/test/java/org/springframework/nativex/HintTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/HintTests.java
@@ -115,8 +115,8 @@ public class HintTests {
 		List<JdkProxyDescriptor> proxies= hint.getProxyDescriptors();
 		assertEquals(1,proxies.size());
 		String[] types = proxies.get(0).getTypes().toArray(new String[] {}); 
-		assertEquals("java.lang.String",types[0]);
-		assertEquals("java.lang.Integer",types[1]);
+		assertEquals("java.lang.Integer",types[0]);
+		assertEquals("java.lang.String",types[1]);
 	}
 
 	@NativeHint(jdkProxies = { @JdkProxyHint(types = { String.class,Integer.class }) })
@@ -260,7 +260,7 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.String");
-		assertThat(cpd.getInterfaceTypes().get(0)).isEqualTo("java.io.Serializable");
+		assertThat(cpd.getInterfaceTypes().first()).isEqualTo("java.io.Serializable");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 
@@ -281,7 +281,7 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.String");
-		assertThat(cpd.getInterfaceTypes().get(0)).isEqualTo("java.util.List");
+		assertThat(cpd.getInterfaceTypes().first()).isEqualTo("java.util.List");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 
@@ -312,12 +312,12 @@ public class HintTests {
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd = (AotProxyDescriptor)proxyDescriptors.get(0);
 		assertThat(cpd.getTargetClassType()).isEqualTo("java.lang.Integer");
-		assertThat(cpd.getInterfaceTypes().get(0)).isEqualTo("java.util.List");
+		assertThat(cpd.getInterfaceTypes().first()).isEqualTo("java.util.List");
 		assertThat(cpd.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 		assertThat(proxyDescriptors.get(0).isClassProxy()).isTrue();
 		AotProxyDescriptor cpd2 = (AotProxyDescriptor)proxyDescriptors.get(1);
 		assertThat(cpd2.getTargetClassType()).isEqualTo("java.lang.Number");
-		assertThat(cpd2.getInterfaceTypes().get(0)).isEqualTo("java.util.List");
+		assertThat(cpd2.getInterfaceTypes().first()).isEqualTo("java.util.List");
 		assertThat(cpd2.getProxyFeatures()).isEqualTo(ProxyBits.EXPOSE_PROXY);
 	}
 	

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
@@ -56,7 +56,7 @@ public class HintDeclarationAssert extends AbstractAssert<HintDeclarationAssert,
 	public HintDeclarationAssert containsProxyFor(Class<?> type) {
 
 		if (!actual.getProxyDescriptors().stream().map(JdkProxyDescriptor::getTypes)
-				.anyMatch(types -> type.getName().equals(types.get(0)))) {
+				.anyMatch(types -> type.getName().equals(types.first()))) {
 
 			failWithMessage("Expected HintDeclaration to contain proxy config for %s but was not in %s",
 					type.getName(), actual.getProxyDescriptors());

--- a/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
+++ b/spring-native-configuration/src/test/java/org/springframework/nativex/util/HintDeclarationAssert.java
@@ -56,7 +56,7 @@ public class HintDeclarationAssert extends AbstractAssert<HintDeclarationAssert,
 	public HintDeclarationAssert containsProxyFor(Class<?> type) {
 
 		if (!actual.getProxyDescriptors().stream().map(JdkProxyDescriptor::getTypes)
-				.anyMatch(types -> type.getName().equals(types.first()))) {
+				.anyMatch(types -> type.getName().equals(types.iterator().next()))) {
 
 			failWithMessage("Expected HintDeclaration to contain proxy config for %s but was not in %s",
 					type.getName(), actual.getProxyDescriptors());

--- a/spring-native/src/main/java/org/springframework/aop/framework/BuildTimeProxyDescriptor.java
+++ b/spring-native/src/main/java/org/springframework/aop/framework/BuildTimeProxyDescriptor.java
@@ -17,8 +17,9 @@
 package org.springframework.aop.framework;
 
 import java.util.Collection;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 
 /**
  * 
@@ -29,13 +30,13 @@ public class BuildTimeProxyDescriptor {
 
 	private final String targetClassName;
 	
-	private final SortedSet<String> interfaceNames;
+	private final Set<String> interfaceNames;
 
 	private final int proxyFeatures; // ProxyBits
 	
 	public BuildTimeProxyDescriptor(String targetClassName, Collection<String> interfaceNames, int proxyFeatures) {
 		this.targetClassName = targetClassName;
-		this.interfaceNames = new TreeSet<String>(interfaceNames);
+		this.interfaceNames = new LinkedHashSet<String>(interfaceNames);
 		this.proxyFeatures = proxyFeatures;
 	}
 
@@ -43,7 +44,7 @@ public class BuildTimeProxyDescriptor {
 		return (proxyFeatures&bit)!=0;
 	}
 
-	public SortedSet<String> getInterfaceTypes() {
+	public Set<String> getInterfaceTypes() {
 		return interfaceNames;
 	}
 

--- a/spring-native/src/main/java/org/springframework/aop/framework/BuildTimeProxyDescriptor.java
+++ b/spring-native/src/main/java/org/springframework/aop/framework/BuildTimeProxyDescriptor.java
@@ -16,23 +16,26 @@
 
 package org.springframework.aop.framework;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * 
  * @author Andy Clement
+ * @author Ariel Carrera
  */
 public class BuildTimeProxyDescriptor {
 
 	private final String targetClassName;
 	
-	private final List<String> interfaceNames;
+	private final SortedSet<String> interfaceNames;
 
 	private final int proxyFeatures; // ProxyBits
 	
-	public BuildTimeProxyDescriptor(String targetClassName, List<String> interfaceNames, int proxyFeatures) {
+	public BuildTimeProxyDescriptor(String targetClassName, Collection<String> interfaceNames, int proxyFeatures) {
 		this.targetClassName = targetClassName;
-		this.interfaceNames = interfaceNames;
+		this.interfaceNames = new TreeSet<String>(interfaceNames);
 		this.proxyFeatures = proxyFeatures;
 	}
 
@@ -40,7 +43,7 @@ public class BuildTimeProxyDescriptor {
 		return (proxyFeatures&bit)!=0;
 	}
 
-	public List<String> getInterfaceTypes() {
+	public SortedSet<String> getInterfaceTypes() {
 		return interfaceNames;
 	}
 


### PR DESCRIPTION
Fix to repeated interface error.
This fix uses a SortedSet instead of a simple HashSet to offers ordering guarantees (generated files should be compared easier).
I test this fix with a sample project and solve the repeated interface error.

Reproducer: [https://github.com/arielcarrera/spring-native-repeated-interface-reproducer](https://github.com/arielcarrera/spring-native-repeated-interface-reproducer)


This should fix #950