### PR TITLE
Update AOT remote debug option in maven plugin

### DIFF
--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/AbstractBootstrapMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/AbstractBootstrapMojo.java
@@ -108,8 +108,8 @@ abstract class AbstractBootstrapMojo extends AbstractMojo {
 	@Parameter(property = "spring.aot.mainClass")
 	protected String mainClass;
 
-	@Parameter(property = "spring.aot.codeGenDebugPort")
-	protected Integer codeGenDebugPort;
+	@Parameter(property = "spring.aot.debug")
+	protected String debug;
 
 	protected AotOptions getAotOptions() {
 		AotOptions aotOptions = new AotOptions();

--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
@@ -33,6 +33,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
@@ -100,9 +101,10 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 
 				List<String> args = new ArrayList<>();
 				// remote debug
-				if (this.codeGenDebugPort != null) {
-					args.add("-Xdebug");
-					args.add("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=" + this.codeGenDebugPort);
+				if ("true".equals(this.debug)) {
+					args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+				} else {
+					args.addAll(Arrays.asList(CommandLineUtils.translateCommandline(this.debug)));
 				}
 				args.add("-cp");
 				args.add(asClasspathArgument(runtimeClasspathElements));

--- a/spring-native-docs/src/main/asciidoc/spring-aot.adoc
+++ b/spring-native-docs/src/main/asciidoc/spring-aot.adoc
@@ -223,15 +223,19 @@ The Spring AOT plugins spawns a new process to perform the source generation. To
 [source,bash,role="primary"]
 .Maven
 ----
-$ mvn -Pnative spring-aot:generate@generate -Dspring.aot.codeGenDebugPort=9000
+$ # use the port 5005 by default
+$ mvn -Pnative spring-aot:generate@generate -Dspring.aot.debug=true
+$ # configure custom debug options
+$ mvn -Pnative spring-aot:generate@generate -Dspring.aot.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000
+$ mvn -Pnative spring-aot:generate@generate -Dspring.aot.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9000 -Xnoagent"
 ----
 [source,bash,role="secondary"]
 .Gradle
 ----
 $ # use the port 5005 by default
-$ ./gradlew generateAot -Pspring.aot.debug=true
+$ ./gradlew generateAot -Dspring.aot.debug=true
 $ # configure a custom port
-$ ./gradlew generateAot -Pspring.aot.debug=true -Dspring.aot.debug.port=9000
+$ ./gradlew generateAot -Dspring.aot.debug=true -Dspring.aot.debug.port=9000
 ----
 
 


### PR DESCRIPTION
Prior to this commit, the remote debugging for maven plugin used
`-Dspring.aot.codeGenDebugPort=<port>`.  This is convenient to specify
port but lacking the ability to specify different options.

This commit changes the parameter to `-Dspring.aot.debug` for maven
plugin.  This aligns with the widely used debug option style, for
example, surefire plugin.  When `-Dspring.aot.debug=true` is specified,
it uses port 5005 for remote debugging.  When othter than `true` is
specified, the value is passed to the AOT code gen process. So, users
can specify more advanced options.

cc @bclozel 