### PR TITLE
Start building against Spring boot 2.6.0 snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 		<revision>0.11.0-SNAPSHOT</revision>
 		<graalvm.version>21.2.0</graalvm.version>
 		<docs.resources.version>0.2.1.RELEASE</docs.resources.version>
-		<spring.boot.version>2.5.5-SNAPSHOT</spring.boot.version>
-		<spring.cloud.version>2020.0.3</spring.cloud.version>
+		<spring.boot.version>2.6.0-SNAPSHOT</spring.boot.version>
+		<spring.cloud.version>2021.0.0-SNAPSHOT</spring.cloud.version>
 		<spring.security.authorization-server.version>0.1.0</spring.security.authorization-server.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>

--- a/samples/maven-parent/pom.xml
+++ b/samples/maven-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.5-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.springframework.experimental</groupId>
@@ -24,7 +24,7 @@
 		<builder>paketobuildpacks/builder:tiny</builder>
 
 		<wavefront.version>2.2.0</wavefront.version>
-		<spring-cloud.version>2020.0.3</spring-cloud.version>
+		<spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<build>

--- a/samples/multi-modules/pom.xml
+++ b/samples/multi-modules/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.5-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/spring-aot-maven-plugin/src/it/runner/pom.xml
+++ b/spring-aot-maven-plugin/src/it/runner/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.5-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.spring.test</groupId>

--- a/spring-aot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanDefinitionOriginAnalyzerTests.java
+++ b/spring-aot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanDefinitionOriginAnalyzerTests.java
@@ -51,7 +51,7 @@ class ConfigurationPropertiesBeanDefinitionOriginAnalyzerTests {
 		BuildTimeBeanDefinitionsRegistrar registrar = new BuildTimeBeanDefinitionsRegistrar();
 		BeanFactoryStructureAnalysis analysis = BeanFactoryStructureAnalysis.of(registrar.processBeanDefinitions(context));
 		this.analyzer.analyze(analysis);
-		assertThat(analysis.resolved()).hasSize(5);
+		assertThat(analysis.resolved()).hasSize(4);
 		HashSet<String> parents = analysis.resolved().map(BeanDefinitionDescriptor::getOrigins)
 				.collect(HashSet::new, Set::addAll, Set::addAll);
 		assertThat(parents).singleElement().satisfies((parent) -> assertThat(parent)

--- a/spring-native/src/main/java/org/springframework/boot/Target_SpringApplication.java
+++ b/spring-native/src/main/java/org/springframework/boot/Target_SpringApplication.java
@@ -100,7 +100,7 @@ final class Target_SpringApplication {
 		this.primarySources = SpringApplicationAotUtils.SPRING_AOT ?
 				new LinkedHashSet<>(Arrays.asList(Object.class)) : new LinkedHashSet<>(Arrays.asList(primarySources));
 		this.webApplicationType = WebApplicationType.deduceFromClasspath();
-		this.bootstrapRegistryInitializers = getBootstrapRegistryInitializersFromSpringFactories();
+		this.bootstrapRegistryInitializers = (List<BootstrapRegistryInitializer>) getSpringFactoriesInstances(BootstrapRegistryInitializer.class);
 		setInitializers((Collection) getSpringFactoriesInstances(ApplicationContextInitializer.class));
 		setListeners((Collection) getSpringFactoriesInstances(ApplicationListener.class));
 		this.mainApplicationClass = deduceMainApplicationClass();
@@ -133,11 +133,6 @@ final class Target_SpringApplication {
 			}
 			loader.load();
 		}
-	}
-
-	@Alias
-	private List<BootstrapRegistryInitializer> getBootstrapRegistryInitializersFromSpringFactories() {
-		return null;
 	}
 
 	@Alias


### PR DESCRIPTION
This upgrades the build to Spring Boot 2.6.0 and Spring Cloud 2021.0.0 snapshots.

Some samples are broken following this upgrade:

* JPA and petclinic-jpa samples (and others Spring Data related) due to a reflection configuration missing for `PropertiesBasedNamedQueries` (that used to be package private). It's unclear why the constructor has to have a reflection entry considering we're not using reflection
* grpc, unrelated to the upgrade. It looks like the version of grpc we use is incompatible with the new generation

The events sample failed locally but I don't really understand why as running it again seems to work.