### PR TITLE
Fix hints for r2dbc and guard hint processor against ClassNotFoundException. 

### DIFF
--- a/spring-aot/src/main/java/org/springframework/context/bootstrap/generator/nativex/HintsBeanNativeConfigurationProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/context/bootstrap/generator/nativex/HintsBeanNativeConfigurationProcessor.java
@@ -86,6 +86,9 @@ class HintsBeanNativeConfigurationProcessor implements BeanNativeConfigurationPr
 					// Types
 					Map<String, AccessDescriptor> dependantTypes = hint.getDependantTypes();
 					for (Map.Entry<String, AccessDescriptor> entry : dependantTypes.entrySet()) {
+						if(!ClassUtils.isPresent(entry.getKey(), null)) {
+							continue;
+						}
 						Class<?> keyClass = ClassUtils.forName(entry.getKey(), null);
 						AccessDescriptor value = entry.getValue();
 						Integer accessBits = value.getAccessBits();

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcHints.java
@@ -51,6 +51,7 @@ import reactor.core.publisher.Mono;
 		@TypeHint(typeNames = "org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerPostProcessor", access = AccessBits.FULL_REFLECTION),
 		@TypeHint(typeNames = "org.springframework.boot.autoconfigure.r2dbc.ConnectionFactoryConfigurations$PooledConnectionFactoryCondition"),
 		@TypeHint(types = {
+				io.r2dbc.spi.Connection.class,
 				R2dbcConverter.class, FluentR2dbcOperations.class, R2dbcEntityOperations.class,
 				ReactiveDataAccessStrategy.class, ReactiveDeleteOperation.class, ReactiveInsertOperation.class,
 				ReactiveSelectOperation.class, ReactiveUpdateOperation.class, AfterConvertCallback.class,


### PR DESCRIPTION
This PR adds missing reflection configuration for r2dbc `Connection` and makes sure hints for types identified via their name do not lead to an unintended `ClassNotFoundException` causing hint computation to abort early.

Fixes the native image of the _data-r2dbc_ sample.