### PR TITLE
Fix cloud-stream-kafka sample for 0.11.x

### DIFF
--- a/samples/cloud-stream-kafka/src/main/java/com/example/demo/SpringCloudStreamKafkaApplication.java
+++ b/samples/cloud-stream-kafka/src/main/java/com/example/demo/SpringCloudStreamKafkaApplication.java
@@ -41,7 +41,10 @@ public class SpringCloudStreamKafkaApplication {
 			String woodchuck = "How much wood a woodchuck chuck if a woodchuck could chuck wood?";
 			final String[] splitWoodchuck = woodchuck.split(" ");
 			Random random = new Random();
-			return splitWoodchuck[random.nextInt(splitWoodchuck.length)];
+
+			final String s = splitWoodchuck[random.nextInt(splitWoodchuck.length)];
+			System.out.println("From Supplier: " + s);
+			return s;
 		};
 	}
 

--- a/samples/cloud-stream-kafka/verify.sh
+++ b/samples/cloud-stream-kafka/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-sleep 2
+sleep 10
 if [[ `cat target/native/test-output.txt | grep -E "Received:(HOW|MUCH|WOOD|A|WOODCHUCK|CHUCK|IF|COULD|WOULD?)"` ]]; then
 	exit 0
 else

--- a/spring-native-configuration/src/main/java/org/springframework/cloud/stream/kafka/KafkaBinderHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/cloud/stream/kafka/KafkaBinderHints.java
@@ -21,6 +21,7 @@ import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderHealthInd
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaExtendedBindingProperties;
 import org.springframework.cloud.stream.function.FunctionConfiguration;
+import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.ResourceHint;
 import org.springframework.nativex.hint.TypeHint;
@@ -33,7 +34,7 @@ import org.springframework.nativex.type.NativeConfiguration;
 						KafkaBinderHealthIndicatorConfiguration.class,
 						KafkaExtendedBindingProperties.class,
 						KafkaBindingProperties.class
-				})
+				}, access = AccessBits.FULL_REFLECTION)
 		})
 @TypeHint(typeNames = {
 		"org.springframework.cloud.stream.function.BindableFunctionProxyFactory",

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -40,7 +40,7 @@ import org.springframework.nativex.type.TypeSystem;
 
 @NativeHint(trigger = JdbcMessageStore.class,
 		resources = @ResourceHint(patterns = "org/springframework/integration/jdbc/schema-.*.sql"))
-@NativeHint(trigger = org.springframework.integration.config.EnableIntegration.class,
+@NativeHint(trigger = org.springframework.integration.config.IntegrationManagementConfiguration.class,
 		initialization =
 		@InitializationHint(initTime = InitializationTime.BUILD,
 				types = {

--- a/spring-native-configuration/src/main/java/org/springframework/kafka/annotation/KafkaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/kafka/annotation/KafkaHints.java
@@ -69,7 +69,7 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
-@NativeHint(trigger=KafkaListenerConfigurationSelector.class,
+@NativeHint(trigger=KafkaListenerAnnotationBeanPostProcessor.class,
 	types = {
 		@TypeHint(types= {
 				PartitionOffset.class,


### PR DESCRIPTION
With the changes in this PR, the sample in `cloud-stream-kafka` is working on `0.11.x` branch for the command: `build.sh --aot-only`. 

However, it fails for the non-aot mode build with `build.sh`.  Do you know why there is a difference between the two modes of build execution?