### PR TITLE
Slight update to Spring IntegrationHints & sample

### DIFF
--- a/samples/integration/build.sh
+++ b/samples/integration/build.sh
@@ -2,6 +2,8 @@
 
 RC=0
 
+docker-compose up -d
 ${PWD%/*samples/*}/scripts/compileWithMaven.sh $* &&  ${PWD%/*samples/*}/scripts/test.sh $* || RC=$?
+docker-compose down
 
 exit $RC

--- a/samples/integration/docker-compose.yml
+++ b/samples/integration/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.1'
+services:
+  redis:
+    image: 'redis:latest'
+    ports:
+      - '6379:6379'

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -40,7 +40,7 @@ import org.springframework.nativex.type.TypeSystem;
 
 @NativeHint(trigger = JdbcMessageStore.class,
 		resources = @ResourceHint(patterns = "org/springframework/integration/jdbc/schema-.*.sql"))
-@NativeHint(trigger = org.springframework.integration.config.EnableIntegration.class,
+@NativeHint(trigger = org.springframework.integration.config.IntegrationManagementConfiguration.class,
 		initialization =
 		@InitializationHint(initTime = InitializationTime.BUILD,
 				types = {


### PR DESCRIPTION
* Since `@EnableIntegration` is based on the `ImportBeanDefinitionRegistrar`,
 we cannot use it as a trigger anymore, change it to `IntegrationManagementConfiguration.class`
* Restore `docker-compose.yml`, but use only for external services
* Add `docker-compose up -d` to `build.sh`

Result: builds AOT-only OK, but does not run:
```
Parameter 0 of method controlBusControllerFlow in com.example.integration.IntegrationApplication required a bean of type 'com.example.integration.ControlBusGateway' that could not be found.
```