### PR TITLE
Allow netty reflection to fix RSS memory usage

### DIFF
--- a/spring-native-configuration/src/main/java/io/netty/NettyHints.java
+++ b/spring-native-configuration/src/main/java/io/netty/NettyHints.java
@@ -26,11 +26,11 @@ import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.resolver.HostsFileEntriesResolver;
-
+import io.netty.util.internal.PlatformDependent;
 import org.springframework.nativex.hint.InitializationHint;
 import org.springframework.nativex.hint.InitializationTime;
-import org.springframework.nativex.type.NativeConfiguration;
 import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.type.NativeConfiguration;
 
 @NativeHint(trigger = DefaultChannelId.class, initialization = {
 		@InitializationHint(initTime=InitializationTime.RUN,
@@ -39,7 +39,7 @@ import org.springframework.nativex.hint.NativeHint;
 				DefaultChannelId.class,
 				Socket.class,
 				Errors.class,
-				Limits.class,IovArray.class,
+				Limits.class, IovArray.class,
 				Http2ServerUpgradeCodec.class,
 				CleartextHttp2ServerUpgradeHandler.class,
 				Http2ConnectionHandler.class,
@@ -49,5 +49,8 @@ import org.springframework.nativex.hint.NativeHint;
 				"io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder"
 		})
 })
+// Enable reflective access for PlatformDependent#useDirectBufferNoCleaner - otherwise there's a strange behaviour with
+// direct memory buffers
+@NativeHint(trigger = PlatformDependent.class, options = "-Dio.netty.tryReflectionSetAccessible=true")
 public class NettyHints implements NativeConfiguration {
 }


### PR DESCRIPTION
See #739

Setting -Dio.netty.tryReflectionSetAccessible=true configures Netty to use the DirectByteBuffer, which solves a bug where the Webflux Netty application used a lot more memory when built with GraalVM 11 vs GraalVM 8.