### PR TITLE
Change the maven default remote debug port from 5005 to 8000

### DIFF
--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
@@ -102,7 +102,7 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 				List<String> args = new ArrayList<>();
 				// remote debug
 				if ("true".equals(this.debug)) {
-					args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+					args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000");
 				} else {
 					args.addAll(Arrays.asList(CommandLineUtils.translateCommandline(this.debug)));
 				}

--- a/spring-native-docs/src/main/asciidoc/spring-aot.adoc
+++ b/spring-native-docs/src/main/asciidoc/spring-aot.adoc
@@ -218,12 +218,13 @@ longest matching prefix in this setting will apply (in cases where a property ma
 
 ==== Debugging the source generation
 
-The Spring AOT plugins spawns a new process to perform the source generation. To remote debug this process, you can set a debug System property on the command line; then, the source generation process launches with a listener accepting a remote debugger on the specified port.
+The Spring AOT plugins spawns a new process to perform the source generation.
+To remote debug this process, you can set a debug System property on the command line; then, the source generation process launches with a listener accepting a remote debugger on port `8000` for Maven or `5005` for Gradle.
 
 [source,bash,role="primary"]
 .Maven
 ----
-$ # use the port 5005 by default
+$ # use the port 8000 by default
 $ mvn -Pnative spring-aot:generate@generate -Dspring.aot.debug=true
 $ # configure custom debug options
 $ mvn -Pnative spring-aot:generate@generate -Dspring.aot.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000


### PR DESCRIPTION
I just realized the surefire uses `5005` as default, but `mvnDebug` uses `8000` as its default remote debugging port.

Also, the spring native documentation ["11.3. Dynamic native configuration"](https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#how-to-contribute-dynamic-native-configuration) mentions port `8000` as default for maven.

To align the default, this PR updates the default remote debug port from `5005` to `8000` for maven.

cc @bclozel 

