### PR TITLE
Append context initializers in aot mode

### DIFF
--- a/spring-native/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-native/src/main/java/org/springframework/boot/SpringApplication.java
@@ -260,17 +260,21 @@ public class SpringApplication {
 		this.webApplicationType = WebApplicationType.deduceFromClasspath();
 		this.bootstrapRegistryInitializers = new ArrayList<>(
 				getSpringFactoriesInstances(BootstrapRegistryInitializer.class));
-		setInitializers((Collection) getSpringFactoriesInstances(ApplicationContextInitializer.class));
 		setListeners((Collection) getSpringFactoriesInstances(ApplicationListener.class));
 		this.mainApplicationClass = deduceMainApplicationClass();
 
 		if (AotModeDetector.isAotModeEnabled()) {
 			logger.info("AOT mode enabled");
 			setApplicationContextFactory(SpringApplicationAotUtils.AOT_FACTORY);
-			setInitializers(Arrays.asList(SpringApplicationAotUtils.getBootstrapInitializer(), new ConditionEvaluationReportLoggingListener()));
+			List<ApplicationContextInitializer<?>> initializers = new ArrayList<>();
+			initializers.add(SpringApplicationAotUtils.getBootstrapInitializer());
+			initializers.add(new ConditionEvaluationReportLoggingListener());
+			initializers.addAll((Collection)getSpringFactoriesInstances(ApplicationContextInitializer.class));
+			setInitializers(initializers);
 		}
 		else {
 			logger.info("AOT mode disabled");
+			setInitializers((Collection) getSpringFactoriesInstances(ApplicationContextInitializer.class));
 		}
 	}
 

--- a/spring-native/src/main/java/org/springframework/boot/Target_SpringApplication.java
+++ b/spring-native/src/main/java/org/springframework/boot/Target_SpringApplication.java
@@ -1,5 +1,6 @@
 package org.springframework.boot;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -102,17 +103,21 @@ final class Target_SpringApplication {
 				new LinkedHashSet<>(Arrays.asList(Object.class)) : new LinkedHashSet<>(Arrays.asList(primarySources));
 		this.webApplicationType = WebApplicationType.deduceFromClasspath();
 		this.bootstrapRegistryInitializers = (List<BootstrapRegistryInitializer>) getSpringFactoriesInstances(BootstrapRegistryInitializer.class);
-		setInitializers((Collection) getSpringFactoriesInstances(ApplicationContextInitializer.class));
 		setListeners((Collection) getSpringFactoriesInstances(ApplicationListener.class));
 		this.mainApplicationClass = deduceMainApplicationClass();
 
 		if (AotModeDetector.isAotModeEnabled()) {
 			logger.info("AOT mode enabled");
 			setApplicationContextFactory(SpringApplicationAotUtils.AOT_FACTORY);
-			setInitializers(Arrays.asList(SpringApplicationAotUtils.getBootstrapInitializer(), new ConditionEvaluationReportLoggingListener()));
+			List<ApplicationContextInitializer<?>> initializers = new ArrayList<>();
+			initializers.add(SpringApplicationAotUtils.getBootstrapInitializer());
+			initializers.add(new ConditionEvaluationReportLoggingListener());
+			initializers.addAll((Collection)getSpringFactoriesInstances(ApplicationContextInitializer.class));
+			setInitializers(initializers);
 		}
 		else {
 			logger.info("AOT mode disabled");
+			setInitializers((Collection) getSpringFactoriesInstances(ApplicationContextInitializer.class));
 		}
 	}
 


### PR DESCRIPTION
This PR adds `ApplicationContextInitializer`s resolved from `spring.factories` in aot mode.

I'm not sure not using them in aot mode is intentional or not.

If it was intentional, then please disregard the PR.
