### PR TITLE
Fix Spring Session Redis WebFlux sample

### DIFF
--- a/samples/session-redis-webflux/build.sh
+++ b/samples/session-redis-webflux/build.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-${PWD%/*samples/*}/scripts/compileWithMaven.sh $* &&  ${PWD%/*samples/*}/scripts/test.sh $*
+RC=0
+
+docker-compose up -d
+${PWD%/*samples/*}/scripts/compileWithMaven.sh $* &&  ${PWD%/*samples/*}/scripts/test.sh $* || RC=$?
+docker-compose down
+
+exit $RC

--- a/samples/session-redis-webflux/pom.xml
+++ b/samples/session-redis-webflux/pom.xml
@@ -15,6 +15,7 @@
 
 	<properties>
 		<java.version>11</java.version>
+		<spring-session-bom.version>2021.1.0-SNAPSHOT</spring-session-bom.version>
 	</properties>
 
 	<dependencies>

--- a/samples/session-redis-webflux/verify.sh
+++ b/samples/session-redis-webflux/verify.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 source ${PWD%/*samples/*}/scripts/wait.sh
-wait_http user:password localhost:8080 "This page is secured"
+wait_http user:password@localhost:8080 "This page is secured"


### PR DESCRIPTION
This PR fixes the session-redis-webflux sample by using the last Spring Session snapshot.
It also includes an enhancement to use docker compose when running the sample.

Relates to gh-1069