### PR TITLE
Add BeforeConvertCallback for DataJdbcHints.

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesHints.java
@@ -40,14 +40,7 @@ import org.springframework.nativex.hint.TypeHint;
 				JdbcRepositoryFactoryBean.class,
 				JdbcRepositoryConfigExtension.class,
 				SimpleJdbcRepository.class,
-				RelationResolver.class,
-				AfterDeleteCallback.class,
-				AfterLoadCallback.class,
-				AfterSaveCallback.class,
-				BeforeConvertCallback.class,
-				BeforeDeleteCallback.class,
-				BeforeSaveCallback.class,
-				RelationalAuditingCallback.class
+				RelationResolver.class
 		}), jdkProxies = @JdkProxyHint(typeNames = {
 				"org.springframework.data.jdbc.core.convert.RelationResolver",
 				"org.springframework.aop.SpringProxy",

--- a/spring-native-configuration/src/main/java/org/springframework/data/jdbc/repository/config/DataJdbcHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/jdbc/repository/config/DataJdbcHints.java
@@ -1,9 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.data.jdbc.repository.config;
 
 import org.springframework.context.annotation.Import;
 import org.springframework.data.DataAuditingHints;
 import org.springframework.data.DataNonReactiveAuditingHints;
-import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.relational.core.mapping.event.AfterConvertCallback;
+import org.springframework.data.relational.core.mapping.event.AfterDeleteCallback;
+import org.springframework.data.relational.core.mapping.event.AfterLoadCallback;
+import org.springframework.data.relational.core.mapping.event.AfterSaveCallback;
+import org.springframework.data.relational.core.mapping.event.BeforeConvertCallback;
+import org.springframework.data.relational.core.mapping.event.BeforeDeleteCallback;
+import org.springframework.data.relational.core.mapping.event.BeforeSaveCallback;
 import org.springframework.data.relational.core.mapping.event.RelationalAuditingCallback;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.TypeHint;
@@ -12,7 +34,16 @@ import org.springframework.nativex.type.NativeConfiguration;
 @Import(DataAuditingHints.class)
 @NativeHint(
 		trigger = AbstractJdbcConfiguration.class,
-		types = @TypeHint(types = RelationalAuditingCallback.class),
+		types = @TypeHint(types = {
+				AfterConvertCallback.class,
+				AfterDeleteCallback.class,
+				AfterLoadCallback.class,
+				AfterSaveCallback.class,
+				BeforeConvertCallback.class,
+				BeforeDeleteCallback.class,
+				BeforeSaveCallback.class,
+				RelationalAuditingCallback.class
+		}),
 		imports = DataNonReactiveAuditingHints.class
 )
 public class DataJdbcHints implements NativeConfiguration {


### PR DESCRIPTION
This PR adds the `AfterConvertCallback` to `DataJdbcHints` because Spring Data JDBC recently moved invocations off its `AfterLoadCallback` to `AfterConvertCallback` (spring-projects/spring-data-jdbc#1053) which had not been present in the current hints.

Along the lines the `ConvertCallback*` hints moved from `JdbcRepositoryHints` to `DataJdbcHints` as those are called by the template and are not repository specific.

Fixes the _data-jdbc_ sample, adds a missing license header and removes an unused import.