### PR TITLE
Upgrade to Native Build Tools 0.9.7.1

### DIFF
--- a/samples/maven-parent/pom.xml
+++ b/samples/maven-parent/pom.xml
@@ -66,6 +66,7 @@
 					<groupId>org.graalvm.buildtools</groupId>
 					<artifactId>native-maven-plugin</artifactId>
 					<version>${native.buildtools.version}</version>
+					<extensions>true</extensions>
 					<executions>
 						<execution>
 							<goals>
@@ -171,14 +172,23 @@
 				<!-- Avoid a clash between Spring Boot repackaging and native-maven-plugin -->
 				<repackage.classifier>exec</repackage.classifier>
 
-				<native.buildtools.version>0.9.5</native.buildtools.version>
+				<native.buildtools.version>0.9.7.1</native.buildtools.version>
 			</properties>
 			<dependencies>
-				<!-- Won't be needed as of JUnit 5.8, see https://github.com/junit-team/junit5/issues/2619 -->
+				<!--
+					Maven Surefire 3.0.0-M4 introduced support for automatically aligning
+					the JUnit Platform version used by Surefire with the version needed
+					by the user's configured version of JUnit Jupiter. Since we are not
+					using Surefire 3.0 milestones, we therefore have to explicitly declare
+					a dependency on the correct version of the junit-platform-launcher in
+					order to have the UniqueIdTrackingListener (introduced in JUnit Platform
+					1.8.0) which is required by Native Build Tools 0.9.6 and higher.
+					The actual version of the junit-platform-launcher is managed by the
+					junit-bom that is imported by the spring-boot-starter-parent.
+				-->
 				<dependency>
-					<groupId>org.graalvm.buildtools</groupId>
-					<artifactId>junit-platform-native</artifactId>
-					<version>${native.buildtools.version}</version>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-launcher</artifactId>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/spring-aot-gradle-plugin/pom.xml
+++ b/spring-aot-gradle-plugin/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.graalvm.buildtools</groupId>
 			<artifactId>native-gradle-plugin</artifactId>
-			<version>0.9.5</version>
+			<version>0.9.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.spring.gradle</groupId>

--- a/spring-native-configuration/src/main/java/org/springframework/boot/test/SpringBootTestHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/test/SpringBootTestHints.java
@@ -12,8 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.FieldHint;
-import org.springframework.nativex.hint.InitializationHint;
-import org.springframework.nativex.hint.InitializationTime;
 import org.springframework.nativex.hint.JdkProxyHint;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.TypeHint;
@@ -29,9 +27,7 @@ import org.springframework.security.web.context.SecurityContextPersistenceFilter
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
-@NativeHint(trigger = org.junit.jupiter.api.Test.class,
-		initialization = @InitializationHint(typeNames = "org.junit.platform.launcher.TestIdentifier", initTime = InitializationTime.BUILD),
-		types = {
+@NativeHint(trigger = org.junit.jupiter.api.Test.class, types = {
 			@TypeHint(types = {
 				SpringBootTest.WebEnvironment.class,
 				org.springframework.test.context.junit.jupiter.SpringExtension.class,


### PR DESCRIPTION
See #1202 for background information.

----

This PR upgrades the `spring-aot-gradle-plugin` and all Maven based sample apps to Native Build Tools (NBT) 0.9.7.1

NBT 0.9.6 requires JUnit Platform 1.8 (JUnit 5.8) due to its dependency on the `UniqueIdTrackingListener` in the `junit-platform-launcher` artifact. The Maven sample apps are currently based on Spring Boot 2.6 RC1 which uses JUnit 5.8.1 (JUnit Platform 1.8.1). Thus, there is no conflict between the JUnit version used in the sample apps and the version used by NBT.

However, there is an issue regarding Maven Surefire.

Maven Surefire 3.0.0-M4 introduced support for automatically aligning the JUnit Platform version used by Surefire with the version needed by the user's configured version of JUnit Jupiter. Since we are not using Surefire 3.0 milestones, the parent POM for the Maven sample apps has to explicitly declare a dependency on the correct version of the `junit-platform-launcher` in order to make the `UniqueIdTrackingListener` available for Native Build Tools 0.9.6 and higher. The actual version of the `junit-platform-launcher` is managed by the junit-bom that is imported by the `spring-boot-starter-parent`.

This PR also removes build-time initialization for `org.junit.platform.launcher.TestIdentifier`, since that is already handled by the `JUnitPlatformFeature` in the Native Build Tools (starting with version 0.9.6). 