### PR TITLE
Transition JpaComponentProcessor to BeanFactoryNativeConfigurationProcessor

### DIFF
--- a/spring-aot/src/main/java/org/springframework/data/JpaConfigurationProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/data/JpaConfigurationProcessor.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.aot.context.bootstrap.generator.infrastructure.nativex.BeanFactoryNativeConfigurationProcessor;
+import org.springframework.aot.context.bootstrap.generator.infrastructure.nativex.DefaultNativeReflectionEntry;
+import org.springframework.aot.context.bootstrap.generator.infrastructure.nativex.NativeConfigurationRegistry;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.annotation.AnnotationFilter;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.nativex.hint.Flag;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Christoph Strobl
+ */
+public class JpaConfigurationProcessor implements BeanFactoryNativeConfigurationProcessor {
+
+	private static Log logger = LogFactory.getLog(JpaConfigurationProcessor.class);
+
+	private static final String JPA_MARKER = "javax.persistence.Entity";
+
+	@Override
+	public void process(ConfigurableListableBeanFactory beanFactory, NativeConfigurationRegistry registry) {
+
+		if (ClassUtils.isPresent(JPA_MARKER, beanFactory.getBeanClassLoader())) {
+			logger.debug("JPA detected - processing types.");
+			new JpaConfigurationProcessor.JpaProcessor(beanFactory.getBeanClassLoader()).process(registry);
+		}
+	}
+
+	static class JpaProcessor {
+
+		private final AnnotationFilter annotationFilter;
+
+		private final Class<? extends Annotation> entityAnnotation;
+		private final Set<JpaImplementation> jpaImplementations;
+		private final ClassLoader classLoader;
+
+		public JpaProcessor(ClassLoader classLoader) {
+
+			this.classLoader = classLoader;
+			entityAnnotation = loadIfPresent("javax.persistence.Entity", classLoader);
+			jpaImplementations = new LinkedHashSet<>(Arrays.asList(new HibernateJpaImplementation()))
+					.stream()
+					.filter(it -> it.isAvailable(classLoader))
+					.collect(Collectors.toSet());
+
+			HashSet<String> availableNamespaces = new HashSet<>();
+			availableNamespaces.add("javax.persistence");
+			jpaImplementations.forEach(it -> availableNamespaces.add(it.getNamespace()));
+			annotationFilter = AnnotationFilter.packages(availableNamespaces.toArray(new String[0]));
+		}
+
+		/**
+		 * Scan the path for JPA entities and process those.
+		 *
+		 * @param registry must not be {@literal null}.
+		 */
+		void process(NativeConfigurationRegistry registry) {
+			process(scanForEntities(), registry);
+		}
+
+		/**
+		 * Process JPA to level entities.
+		 *
+		 * @param entities
+		 * @param registry
+		 */
+		void process(Set<Class<?>> entities, NativeConfigurationRegistry registry) {
+			TypeModelProcessor typeModelProcessor = new TypeModelProcessor();
+			entities.forEach(type -> {
+
+				/*
+				 * If an EntityListener is defined we need to inspect the target and make sure
+				 * reflection is configured so the methods can be invoked
+				 */
+				MergedAnnotation<Annotation> entityListener = MergedAnnotations.from(type).get("javax.persistence.EntityListeners");
+				if (entityListener.isPresent()) {
+					Class<?>[] values = entityListener.getClassArray("value");
+					for (Class<?> listener : values) {
+						registry.reflection().forType(listener).withFlags(Flag.allDeclaredConstructors, Flag.allPublicMethods);
+					}
+				}
+
+				/*
+				 * Retrieve all reachable types and register reflection for it.
+				 * Final fields require special treatment having allowWrite set.
+				 */
+				typeModelProcessor.inspect(type).forEach(typeModel -> {
+
+					DefaultNativeReflectionEntry.Builder builder = registry.reflection().forType(typeModel.getType());
+					builder.withFlags(Flag.allDeclaredFields, Flag.allDeclaredMethods, Flag.allDeclaredConstructors);
+
+					typeModel.doWithFields(field -> {
+						if (Modifier.isFinal(field.getModifiers())) {
+							builder.withField(field, DefaultNativeReflectionEntry.FieldAccess.ALLOW_WRITE, DefaultNativeReflectionEntry.FieldAccess.UNSAFE);
+						}
+					});
+
+					typeModel.doWithAnnotatedElements(element -> {
+						writeAnnotationConfigurationFor(element, registry);
+					});
+
+					jpaImplementations.forEach(it -> it.process(typeModel, classLoader, registry));
+				});
+			});
+		}
+
+		/**
+		 * Write the required configuration for annotations that belong to the persistence namespace
+		 *
+		 * @param element
+		 * @param registry
+		 */
+		private void writeAnnotationConfigurationFor(AnnotatedElement element, NativeConfigurationRegistry registry) {
+			TypeUtils.resolveAnnotationsFor(element)
+					.map(MergedAnnotation::getType)
+					.filter(annotationFilter::matches)
+					.forEach(annotation -> {
+						registry.reflection().forType(annotation).withFlags(Flag.allPublicConstructors, Flag.allPublicMethods);
+					});
+			if (element instanceof Constructor) {
+				for (Parameter parameter : ((Constructor<?>) element).getParameters()) {
+					writeAnnotationConfigurationFor(parameter, registry);
+				}
+			}
+			if (element instanceof Method) {
+				for (Parameter parameter : ((Method) element).getParameters()) {
+					writeAnnotationConfigurationFor(parameter, registry);
+				}
+			}
+		}
+
+		/**
+		 * Scan the classpath for types annotated with {@link #JPA_MARKER}
+		 *
+		 * @return the {@link Set} of top level entities.
+		 */
+		Set<Class<?>> scanForEntities() {
+
+			if (entityAnnotation == null) {
+				return Collections.emptySet();
+			}
+
+			ClassPathScanningCandidateComponentProvider componentProvider = new ClassPathScanningCandidateComponentProvider(false, new StandardEnvironment());
+			componentProvider.setResourceLoader(new DefaultResourceLoader(classLoader));
+			componentProvider.addIncludeFilter(new AnnotationTypeFilter(entityAnnotation));
+
+			Set<Class<?>> entities = new LinkedHashSet<>();
+			for (BeanDefinition definition : componentProvider.findCandidateComponents("")) {
+
+				Class<?> type = loadIfPresent(definition.getBeanClassName(), classLoader);
+				if (type == null) {
+					continue;
+				}
+
+				logger.debug("JPA entity" + type + " found on path.");
+				entities.add(type);
+			}
+			return entities;
+		}
+	}
+
+	private interface JpaImplementation {
+
+		String getNamespace();
+
+		boolean isAvailable(ClassLoader classLoader);
+
+		void process(TypeModel type, ClassLoader classLoader, NativeConfigurationRegistry registry);
+	}
+
+	private static class HibernateJpaImplementation implements JpaImplementation {
+
+		private Boolean present;
+
+		@Override
+		public String getNamespace() {
+			return "org.hibernate";
+		}
+
+		@Override
+		public boolean isAvailable(ClassLoader classLoader) {
+			if (present == null) {
+				present = ClassUtils.isPresent("org.hibernate.Hibernate", classLoader);
+			}
+			return present;
+		}
+
+		@Override
+		public void process(TypeModel type, ClassLoader classLoader, NativeConfigurationRegistry registry) {
+			if (!type.getType().isEnum()) {
+				return;
+			}
+			Class<Object> objectClass = loadIfPresent("org.hibernate.type.EnumType", classLoader);
+			if (objectClass != null) {
+				registry.reflection().forType(objectClass).withFlags(Flag.allDeclaredConstructors);
+			}
+		}
+	}
+
+	private static <T> Class<T> loadIfPresent(String name, ClassLoader classLoader) {
+
+		try {
+			return (Class<T>) ClassUtils.forName(name, classLoader);
+		} catch (ClassNotFoundException e) {
+			//
+		}
+		return null;
+	}
+}

--- a/spring-aot/src/main/java/org/springframework/data/TypeModel.java
+++ b/spring-aot/src/main/java/org/springframework/data/TypeModel.java
@@ -31,14 +31,12 @@ import java.util.stream.Collectors;
 import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.data.TypeUtils.TypeOps;
 import org.springframework.data.TypeUtils.TypeOps.PackageFilter;
-import org.springframework.data.annotation.PersistenceConstructor;
-import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
 /**
  * Entry point to access {@link Field fields}, {@link Method methods} and {@link Constructor constructors} honoring
- * {@link PersistenceConstructor} annotation.
+ * {@literal org.springframework.data.annotation.PersistenceConstructor} annotation.
  *
  * @author Christoph Strobl
  */

--- a/spring-aot/src/main/java/org/springframework/data/TypeUtils.java
+++ b/spring-aot/src/main/java/org/springframework/data/TypeUtils.java
@@ -18,6 +18,7 @@ package org.springframework.data;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.LinkedHashSet;
@@ -53,6 +54,29 @@ public class TypeUtils {
 
 	public static Set<Class<?>> resolveAnnotationTypesFor(AnnotatedElement element) {
 		return resolveAnnotationTypesFor(element, AnnotationFilter.PLAIN);
+	}
+
+	public static boolean hasAnnotatedField(Class<?> type, String annotationName) {
+
+		for (Field field: type.getDeclaredFields()) {
+			MergedAnnotations fieldAnnotations = MergedAnnotations.from(field);
+			boolean hasAnnotation = fieldAnnotations.get(annotationName).isPresent();
+			if (hasAnnotation) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static Set<Field> getAnnotatedField(Class<?> type, String annotationName) {
+
+		Set<Field> fields = new LinkedHashSet<>();
+		for (Field field: type.getDeclaredFields()) {
+			if (MergedAnnotations.from(field).get(annotationName).isPresent()) {
+				fields.add(field);
+			}
+		}
+		return fields;
 	}
 
 	public static Set<Class<?>> resolveTypesInSignature(Class<?> owner, Method method) {

--- a/spring-aot/src/main/resources/META-INF/spring.factories
+++ b/spring-aot/src/main/resources/META-INF/spring.factories
@@ -18,6 +18,7 @@ org.springframework.boot.actuate.endpoint.annotation.EndpointNativeConfiguration
 org.springframework.boot.actuate.endpoint.annotation.HealthContributorNativeConfigurationProcessor,\
 org.springframework.boot.context.AotProxyNativeConfigurationProcessor,\
 org.springframework.boot.context.properties.ConfigurationPropertiesNativeConfigurationProcessor,\
+org.springframework.data.JpaConfigurationProcessor,\
 org.springframework.data.RepositoryDefinitionConfigurationProcessor,\
 org.springframework.repository.annotation.RepositoryComponentConfigurationProcessor,\
 org.springframework.transaction.annotation.TransactionalNativeConfigurationProcessor,\

--- a/spring-aot/src/test/java/org/springframework/data/JpaConfigurationProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/data/JpaConfigurationProcessorTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.context.bootstrap.generator.infrastructure.nativex.NativeConfigurationRegistry;
+import org.springframework.aot.context.bootstrap.generator.infrastructure.nativex.NativeReflectionEntry;
+import org.springframework.nativex.domain.reflect.ClassDescriptor;
+import org.springframework.nativex.domain.reflect.FieldDescriptor;
+import org.springframework.sample.data.jpa.AuditingListener;
+import org.springframework.sample.data.jpa.EntityWithListener;
+import org.springframework.sample.data.jpa.LineItem;
+import org.springframework.sample.data.jpa.NotAnEntity;
+import org.springframework.sample.data.jpa.Order;
+import org.springframework.sample.data.jpa.SomeAnnotation;
+
+/**
+ * Tests for {@link JpaConfigurationProcessor}.
+ *
+ * @author Christoph Strobl
+ */
+public class JpaConfigurationProcessorTests {
+
+	@Test
+	void shouldIncludeReachableTypes() {
+
+		assertThat(process(Order.class)).satisfies(it -> {
+			assertThat(it.hasReflectionEntry(Order.class)).isTrue();
+			assertThat(it.hasReflectionEntry(LineItem.class)).isTrue();
+			assertThat(it.hasReflectionEntry(NotAnEntity.class)).isFalse();
+		});
+	}
+
+	@Test
+	public void shouldRegisterReflectionAllowWriteForFinalFields/* looking at you hibernate */() {
+
+		assertThat(process(Order.class)).satisfies(it -> {
+
+			ClassDescriptor classDescriptor = it.getReflectionEntry(Order.class).toClassDescriptor();
+			Optional<FieldDescriptor> id = classDescriptor.getFields().stream().filter(field -> {
+				return field.getName().equals("id");
+			}).findFirst();
+			assertThat(id).isPresent().contains(new FieldDescriptor("id", true, true));
+		});
+	}
+
+	@Test
+	public void shouldNotDoFancyStuffForNonFinalFields/* looking at you hibernate */() {
+
+		assertThat(process(Order.class)).satisfies(it -> {
+
+			ClassDescriptor classDescriptor = it.getReflectionEntry(Order.class).toClassDescriptor();
+			Optional<FieldDescriptor> name = classDescriptor.getFields().stream().filter(field -> {
+				return field.getName().equals("name");
+			}).findFirst();
+			assertThat(name).isNotPresent();
+		});
+	}
+
+	@Test
+	public void shouldAddReflectionForJavaxPersistenceAnnotations() {
+
+		assertThat(process(Order.class)).satisfies(it -> {
+
+			assertThat(it.hasReflectionEntry(Entity.class)).isTrue();
+			assertThat(it.hasReflectionEntry(GeneratedValue.class)).isTrue();
+			assertThat(it.hasReflectionEntry(OneToMany.class)).isTrue();
+			assertThat(it.hasReflectionEntry(ManyToOne.class)).isTrue();
+		});
+	}
+
+	@Test
+	public void whatAboutOtherAnnotations/* like jackson */() {
+
+		assertThat(process(Order.class)).satisfies(it -> {
+			assertThat(it.hasReflectionEntry(SomeAnnotation.class)).isFalse();
+		});
+	}
+
+	@Test
+	@Disabled("use a shadowing class loader maybe to test this?")
+	public void shouldRegisterHibernateEnumTypeOnlyIfModelIsUsingEnums() {
+
+//		assertThat(process(EntityWithEnum.class)).satisfies(it -> {
+//			assertThat(it.hasReflectionEntry(org.hibernate.type.EnumType.class)).isTrue();
+//		});
+	}
+
+	@Test
+	public void shouldAddFullReflectionForEntityListener() {
+
+		assertThat(process(EntityWithListener.class)).satisfies(it -> {
+			assertThat(it.hasReflectionEntry(AuditingListener.class)).isTrue();
+		});
+	}
+
+
+	NativeConfigRegistryHolder process(Class<?>... entities) {
+
+		NativeConfigurationRegistry registry = new NativeConfigurationRegistry();
+		new JpaConfigurationProcessor.JpaProcessor(this.getClass().getClassLoader()).process(new LinkedHashSet<>(Arrays.asList(entities)), registry);
+		return new NativeConfigRegistryHolder(registry);
+	}
+
+	static class NativeConfigRegistryHolder {
+
+		NativeConfigurationRegistry delegate;
+
+		NativeConfigRegistryHolder(NativeConfigurationRegistry registry) {
+			this.delegate = registry;
+		}
+
+		NativeReflectionEntry getReflectionEntry(Class<?> type) {
+			return delegate.reflection().forType(type).build();
+		}
+
+		boolean hasReflectionEntry(Class<?> type) {
+			return delegate.reflection().reflectionEntries().anyMatch(it -> it.getType().equals(type));
+		}
+	}
+}

--- a/spring-aot/src/test/java/org/springframework/nativex/type/TypeProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/nativex/type/TypeProcessorTests.java
@@ -150,7 +150,7 @@ class TypeProcessorTests {
 				.skipAnnotationInspection()
 				.skipMethodInspection()
 				.skipFieldInspection()
-				.use(typeSystem).toProcessTypesMatching(type -> type.getName().endsWith("NotAnEntity"));
+				.use(typeSystem).toProcessTypesMatching(type -> type.getDottedName().endsWith("entities.NotAnEntity"));
 
 		assertThat(hints).hasSize(1);
 		assertThat(capturedTypes).containsExactly("org.springframework.nativex.type.entities.NotAnEntity");

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/AuditingListener.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/AuditingListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.PrePersist;
+import javax.persistence.PreRemove;
+import javax.persistence.PreUpdate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuditingListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditingListener.class);
+
+    @PrePersist
+    @PreUpdate
+    @PreRemove
+    private void beforeAnyOperation(Object object) {
+        LOGGER.info("Operation performed on {}", object);
+    }
+
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/ComponentWithPersistenceContext.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/ComponentWithPersistenceContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ComponentWithPersistenceContext {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	private String doesNotNeedReflection;
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/DualEnum.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/DualEnum.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+public enum DualEnum {
+	ZERO, ONE
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithAnnotations.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithAnnotations.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+
+@Entity
+public class EntityWithAnnotations {
+
+	@GeneratedValue
+	private Long id; // simple value
+
+	@SomeAnnotation // annotation with meta annotation @Nullable
+	String name;
+
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithEnum.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithEnum.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+
+@Entity
+public class EntityWithEnum {
+
+	@GeneratedValue
+	private Long id;
+	private DualEnum dual;
+
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithListener.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+
+@EntityListeners(AuditingListener.class)
+@Entity
+public class EntityWithListener {
+
+	@GeneratedValue
+	private Long id; // simple value
+
+	@SomeAnnotation // annotation with meta annotation @Nullable
+	String name;
+
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/LineItem.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/LineItem.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import org.springframework.beans.factory.annotation.Value;
+
+@Entity
+public class LineItem {
+
+	private String name;
+
+	@ManyToOne
+	Order orderReference; // cycle back to Order
+
+	LineItem() {
+
+	}
+
+	LineItem(@Value("---") String name) {
+		this.name = name;
+	}
+
+	// no methods what so ever
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/NotAnEntity.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/NotAnEntity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+public class NotAnEntity {
+
+	String id;
+	String value;
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/Order.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/Order.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.OneToMany;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Christoph Strobl
+ */
+@Entity // annotation on entity
+public class Order {
+
+	@GeneratedValue
+	private final Long id; // simple value
+
+	@SomeAnnotation // annotation with meta annotation @Nullable
+	String name;
+
+	@OneToMany // javax.persistence annotation
+	List<LineItem> itemList; // List and element type with
+
+	public Order() {
+		this(null);
+	}
+
+	public Order(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public List<LineItem> getItemList() {
+		return itemList;
+	}
+	
+	public Date getOrderDate() { // capture method return type
+		return null;
+	}
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/SomeAnnotation.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/SomeAnnotation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.annotation.Nullable;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Inherited
+@Nullable
+public @interface SomeAnnotation {
+
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/WithFinalField.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/WithFinalField.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+/**
+ * @author Christoph Strobl
+ */
+public class WithFinalField {
+
+	private Long id;
+	private final String name;
+
+	public WithFinalField() {
+		this.name = null;
+	}
+}

--- a/spring-native-configuration/src/main/java/org/springframework/data/JpaComponentProcessor.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/JpaComponentProcessor.java
@@ -73,19 +73,19 @@ public class JpaComponentProcessor implements ComponentProcessor {
 	public void process(NativeContext imageContext, String componentType, List<String> classifiers) {
 
 		Type domainType = imageContext.getTypeSystem().resolveName(componentType);
-		typeProcessor.use(imageContext).toProcessType(domainType);
+//		typeProcessor.use(imageContext).toProcessType(domainType);
 
-		for (String listener : domainType.findAnnotationValue(ENTITY_LISTENERS, false, false)) {
-			Type listenerType = imageContext.getTypeSystem().Lresolve(listener);
-			List<MethodDescriptor> methodDescriptors = listenerType
-					.getMethods(method -> method.getAnnotationTypes().stream().anyMatch(
-							type -> type.getDottedName().startsWith("javax.persistence")))
-					.stream()
-					.map(it -> new MethodDescriptor(it.getName(), Arrays.asList(it.asConfigurationArray())))
-					.collect(Collectors.toList());
-
-			imageContext.addReflectiveAccess(listenerType.getDottedName(), new AccessDescriptor(AccessBits.LOAD_AND_CONSTRUCT, methodDescriptors, Collections.emptyList(), Collections.emptyList()));
-		}
+//		for (String listener : domainType.findAnnotationValue(ENTITY_LISTENERS, false, false)) {
+//			Type listenerType = imageContext.getTypeSystem().Lresolve(listener);
+//			List<MethodDescriptor> methodDescriptors = listenerType
+//					.getMethods(method -> method.getAnnotationTypes().stream().anyMatch(
+//							type -> type.getDottedName().startsWith("javax.persistence")))
+//					.stream()
+//					.map(it -> new MethodDescriptor(it.getName(), Arrays.asList(it.asConfigurationArray())))
+//					.collect(Collectors.toList());
+//
+//			imageContext.addReflectiveAccess(listenerType.getDottedName(), new AccessDescriptor(AccessBits.LOAD_AND_CONSTRUCT, methodDescriptors, Collections.emptyList(), Collections.emptyList()));
+//		}
 	}
 
 	private void registerAnnotationInConfiguration(Type annotation, NativeContext context) {

--- a/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.ComponentProcessor
+++ b/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.ComponentProcessor
@@ -1,5 +1,4 @@
 org.springframework.web.WebComponentProcessor
-org.springframework.PersistentContextMarkedComponentProcessor
 org.springframework.SynthesizerComputationComponentProcessor
 org.springframework.TransactionalEventListenerComponentProcessor
 org.springframework.ValidatedComponentProcessor

--- a/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.ComponentProcessor
+++ b/spring-native-configuration/src/main/resources/META-INF/services/org.springframework.nativex.type.ComponentProcessor
@@ -1,4 +1,3 @@
-org.springframework.data.JpaComponentProcessor
 org.springframework.web.WebComponentProcessor
 org.springframework.PersistentContextMarkedComponentProcessor
 org.springframework.SynthesizerComputationComponentProcessor

--- a/spring-native-configuration/src/test/java/org/springframework/data/JpaComponentProcessorTests.java
+++ b/spring-native-configuration/src/test/java/org/springframework/data/JpaComponentProcessorTests.java
@@ -25,7 +25,9 @@ import java.util.Collections;
 
 import org.hibernate.type.EnumType;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.data.jpa.entities.AuditingListener;
 import org.springframework.data.jpa.entities.EntityWithEnum;
 import org.springframework.data.jpa.entities.EntityWithListener;
@@ -39,6 +41,7 @@ import org.springframework.nativex.type.MethodDescriptor;
 import org.springframework.nativex.type.TypeSystem;
 import org.springframework.nativex.util.NativeTestContext;
 
+@Ignore
 public class JpaComponentProcessorTests {
 
 


### PR DESCRIPTION
Replace the `JpaComponentProcessor` with a `BeanFactoryNativeConfigurationProcessor` implementation.

Resolves: #1208