### PR TITLE
Corrected incorrect docker image name that is generated under asciidoc

### DIFF
--- a/spring-native-docs/src/main/asciidoc/getting-started-buildpacks.adoc
+++ b/spring-native-docs/src/main/asciidoc/getting-started-buildpacks.adoc
@@ -330,7 +330,7 @@ To run the application, you can use `docker` the usual way as shown in the follo
 
 [source,bash]
 ----
-$ docker run --rm -p 8080:8080 rest-service:0.0.1-SNAPSHOT
+$ docker run --rm -p 8080:8080 rest-service-complete:0.0.1-SNAPSHOT
 ----
 
 
@@ -341,7 +341,7 @@ If you prefer `docker-compose`, you can write a `docker-compose.yml` at the root
 version: '3.1'
 services:
   rest-service:
-    image: rest-service:0.0.1-SNAPSHOT
+    image: rest-service-complete:0.0.1-SNAPSHOT
     ports:
       - "8080:8080"
 ----


### PR DESCRIPTION
This PR addresses the incorrect image name under the spring-native/asciidoc/getting-started-buildpacks.adoc

In that file, the name of the image generated is ``rest-service-complete`` which is incorrectly mentioned in the documentation to be ``rest-service``.

Check here: https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#_run_the_native_application