### PR TITLE
avoid NPE and improve log message, default application class if missing

### DIFF
--- a/spring-aot/src/main/java/org/springframework/aot/build/ApplicationStructure.java
+++ b/spring-aot/src/main/java/org/springframework/aot/build/ApplicationStructure.java
@@ -64,7 +64,8 @@ public class ApplicationStructure {
 		this.classesPaths = classesPaths;
 		this.mainClass = mainClass != null ? mainClass : detectMainClass(classesPaths);
 		this.testClasses = testClasses;
-		this.applicationClass = detectApplicationClass(classesPaths);
+		String applicationClass = detectApplicationClass(classesPaths);
+		this.applicationClass = applicationClass == null ? mainClass : applicationClass;
 		this.classpath = classpath;
 		this.classLoader = classLoader;
 	}

--- a/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/InitDestroyMethodsDiscoverer.java
+++ b/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/InitDestroyMethodsDiscoverer.java
@@ -71,10 +71,10 @@ class InitDestroyMethodsDiscoverer {
 		Set<Method> methods = new LinkedHashSet<>();
 		String initMethodName = beanDefinition.getInitMethodName();
 		if (StringUtils.hasText(initMethodName)) {
-			methods.add(findMethod(beanType, initMethodName));
+			methods.add(findMethod(beanDefinition, beanType, initMethodName));
 		}
 		for (String methodName : getExternallyManagedInitMethods(beanDefinition)) {
-			methods.add(findMethod(beanType, methodName));
+			methods.add(findMethod(beanDefinition, beanType, methodName));
 		}
 		return methods;
 	}
@@ -117,10 +117,10 @@ class InitDestroyMethodsDiscoverer {
 			}
 		}
 		else if (StringUtils.hasText(destroyMethodName)) {
-			methods.add(findMethod(beanType, destroyMethodName));
+			methods.add(findMethod(beanDefinition, beanType, destroyMethodName));
 		}
 		for (String methodName : getExternallyManagedDestroyMethods(beanDefinition)) {
-			methods.add(findMethod(beanType, methodName));
+			methods.add(findMethod(beanDefinition, beanType, methodName));
 		}
 		return methods;
 	}
@@ -176,10 +176,10 @@ class InitDestroyMethodsDiscoverer {
 		return null;
 	}
 
-	private Method findMethod(Class<?> beanType, String methodName) {
+	private Method findMethod(BeanDefinition beanDefinition, Class<?> beanType, String methodName) {
 		Method method = ReflectionUtils.findMethod(beanType, methodName);
 		if (method == null) {
-			throw new IllegalStateException("Lifecycle method annotation '" + methodName + "' not found on: " + beanType);
+			throw new IllegalStateException("Lifecycle method annotation '" + methodName + "' not found on: " + beanType + " for bean definition: " + beanDefinition);
 		}
 		return method;
 	}

--- a/spring-aot/src/main/java/org/springframework/nativex/type/TypeSystem.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/TypeSystem.java
@@ -1349,10 +1349,10 @@ public class TypeSystem {
 			File f = new File(classpathEntry);
 			if (f.isDirectory()) {
 				result.add(Paths.get(f.toURI()));
-			} else if (f.isFile() && f.getName().endsWith(".jar") && (
-					f.getParent().endsWith(File.separator + "target") ||  // Maven multi-module
-							f.getParent().endsWith(File.separator + "libs") || // Gradle multi-module
-							f.getAbsolutePath().contains(mainPackagePath))) { // Same package than the main application class
+			} else if (mainPackagePath != null && f.isFile() && f.getName().endsWith(".jar") && (
+				f.getParent().endsWith(File.separator + "target") ||  // Maven multi-module
+					f.getParent().endsWith(File.separator + "libs") || // Gradle multi-module
+					f.getAbsolutePath().contains(mainPackagePath))) { // Same package than the main application class
 				result.add(Paths.get(f.toURI()));
 			}
 		}


### PR DESCRIPTION
I was specifying mainClass in the build (b/c my main class is in a dependency jar) but it was not getting used in the `generateAotTest` task of the build so this adds a null check. 

The private `findMethod` looking for destroy methods was confused by a FactoryBean that was explicitly setting a destroy method and then not finding it on the `FactoryBean` interface. In my case the `FactoryBean` returned a `DisposableBean` so it didn't need to set the destroy method, but this change adds the bean definition to the exception thrown so it is easier to identify where the problem is. 

This also defaults applicationClass to mainClass if applicationClass isn't discovered. Maybe applicationClass should be configurable like mainClass but even if it were, mainClass might be a reasonable default? If that isn't the case I can look at making applicationClass configurable via the plugins. 