### PR TITLE
Add flyway hints

### DIFF
--- a/spring-native-configuration/pom.xml
+++ b/spring-native-configuration/pom.xml
@@ -158,6 +158,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.experimental</groupId>
             <artifactId>spring-aot</artifactId>
         </dependency>

--- a/spring-native-configuration/src/main/java/org/flywaydb/FeatureDetectorSubstitutions.java
+++ b/spring-native-configuration/src/main/java/org/flywaydb/FeatureDetectorSubstitutions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flywaydb;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * FeatureDetector substitution.
+ * <p>
+ * Forked from micronaut:
+ * https://github.com/micronaut-projects/micronaut-flyway/blob/758da7d56280f5b923b2e09a1849e82974679e64/flyway/src/main/java/io/micronaut/flyway/graalvm/FeatureDetectorSubstitutions.java
+ * <p>
+ * Which was forked from Quarkus:
+ * https://github.com/quarkusio/quarkus/blob/38280358d8cf04b91dad7ef5a9d463823f8ae675/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/FeatureDetectorSubstitutions.java
+ */
+@Substitute
+@TargetClass(className = "org.flywaydb.core.internal.util.FeatureDetector")
+public final class FeatureDetectorSubstitutions {
+
+		@Substitute
+		public FeatureDetectorSubstitutions(ClassLoader classLoader) {
+		}
+
+		@Substitute
+		public boolean isApacheCommonsLoggingAvailable() {
+				return false;
+		}
+
+		@Substitute
+		public boolean isLog4J2Available() {
+				return false;
+		}
+
+		@Substitute
+		public boolean isSlf4jAvailable() {
+				return true;
+		}
+
+		@Substitute
+		public boolean isJBossVFSv2Available() {
+				return false;
+		}
+
+		@Substitute
+		public boolean isJBossVFSv3Available() {
+				return false;
+		}
+
+		@Substitute
+		public boolean isOsgiFrameworkAvailable() {
+				return false;
+		}
+
+		@Substitute
+		public boolean isAwsAvailable() {
+				return false;
+		}
+
+		@Substitute
+		public boolean isGCSAvailable() {
+				return false;
+		}
+
+}

--- a/spring-native-configuration/src/main/java/org/flywaydb/FlywayFeature.java
+++ b/spring-native-configuration/src/main/java/org/flywaydb/FlywayFeature.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flywaydb;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A GraalVM feature that calculates the migration to apply at compile time.
+ * <p>
+ * Forked from micronaut:
+ * https://github.com/micronaut-projects/micronaut-flyway/blob/758da7d56280f5b923b2e09a1849e82974679e64/flyway/src/main/java/io/micronaut/flyway/graalvm/FlywayFeature.java
+ * <p>
+ * Which was forked from Quarkus:
+ * https://github.com/quarkusio/quarkus/blob/7a5efed2a97d88656484b431b472210e2bb7d2f3/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+ */
+@AutomaticFeature
+public final class FlywayFeature implements Feature {
+
+		private static final Log LOG = LogFactory.getLog(FlywayFeature.class);
+
+		private static final String CLASSPATH_APPLICATION_MIGRATIONS_PROTOCOL = "classpath";
+		private static final String JAR_APPLICATION_MIGRATIONS_PROTOCOL = "jar";
+		private static final String FILE_APPLICATION_MIGRATIONS_PROTOCOL = "file";
+
+		private static final String FLYWAY_LOCATIONS = "flyway.locations";
+		private static final String DEFAULT_FLYWAY_LOCATIONS = "classpath:db/migration";
+
+		@Override
+		public void beforeAnalysis(BeforeAnalysisAccess access) {
+				List<String> locations = Stream
+						.of(System.getProperty(FLYWAY_LOCATIONS, DEFAULT_FLYWAY_LOCATIONS).split(",")).collect(Collectors.toList());
+
+				try {
+						List<String> migrations = discoverApplicationMigrations(locations);
+						NativePathLocationScanner.setApplicationMigrationFiles(migrations);
+				} catch (IOException | URISyntaxException e) {
+						LOG.error("There was an error discovering the Flyway migrations: " + e.getMessage());
+				}
+		}
+
+		private List<String> discoverApplicationMigrations(List<String> locations) throws IOException, URISyntaxException {
+				List<String> applicationMigrationResources = new ArrayList<>();
+				// Locations can be a comma separated list
+				for (String location : locations) {
+						// Strip any 'classpath:' protocol prefixes because they are assumed
+						// but not recognized by ClassLoader.getResources()
+						if (location != null && location.startsWith(CLASSPATH_APPLICATION_MIGRATIONS_PROTOCOL + ':')) {
+								location = location.substring(CLASSPATH_APPLICATION_MIGRATIONS_PROTOCOL.length() + 1);
+						}
+						Enumeration<URL> migrations = Thread.currentThread().getContextClassLoader().getResources(location);
+						while (migrations.hasMoreElements()) {
+								URL path = migrations.nextElement();
+								LOG.debug("Adding application migrations in path '" + path.getPath() + "' using protocol '" + path.getProtocol() + "'");
+								final Set<String> applicationMigrations;
+								if (JAR_APPLICATION_MIGRATIONS_PROTOCOL.equals(path.getProtocol())) {
+										try (FileSystem fileSystem = initFileSystem(path.toURI())) {
+												applicationMigrations = getApplicationMigrationsFromPath(location, path);
+										}
+								} else if (FILE_APPLICATION_MIGRATIONS_PROTOCOL.equals(path.getProtocol())) {
+										applicationMigrations = getApplicationMigrationsFromPath(location, path);
+								} else {
+										LOG.warn("Unsupported URL protocol '" + path.getProtocol() + "' for path '" + path.getPath() + "'. Migration files will not be discovered.");
+										applicationMigrations = null;
+								}
+								if (applicationMigrations != null) {
+										applicationMigrationResources.addAll(applicationMigrations);
+								}
+						}
+				}
+				return applicationMigrationResources;
+		}
+
+		private Set<String> getApplicationMigrationsFromPath(final String location, final URL path)
+				throws IOException, URISyntaxException {
+				try (Stream<Path> pathStream = Files.walk(Paths.get(path.toURI()))) {
+						return pathStream.filter(Files::isRegularFile)
+								.map(it -> Paths.get(location, it.getFileName().toString()).toString())
+								// we don't want windows paths here since the paths are going to be used as classpath paths anyway
+								.map(it -> it.replace('\\', '/'))
+								.peek(it -> LOG.debug("Discovered path: " + it))
+								.collect(Collectors.toSet());
+				}
+		}
+
+		private FileSystem initFileSystem(final URI uri) throws IOException {
+				final Map<String, String> env = new HashMap<>();
+				env.put("create", "true");
+				return FileSystems.newFileSystem(uri, env);
+		}
+
+}

--- a/spring-native-configuration/src/main/java/org/flywaydb/FlywayHints.java
+++ b/spring-native-configuration/src/main/java/org/flywaydb/FlywayHints.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flywaydb;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.internal.logging.buffered.BufferedLogCreator;
+import org.flywaydb.core.internal.logging.slf4j.Slf4jLogCreator;
+import org.flywaydb.core.internal.util.FeatureDetector;
+import org.springframework.nativex.hint.InitializationHint;
+import org.springframework.nativex.hint.InitializationTime;
+import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.ResourceHint;
+import org.springframework.nativex.hint.TypeHint;
+import org.springframework.nativex.type.NativeConfiguration;
+
+@NativeHint(trigger = Flyway.class,
+		initialization = {
+				@InitializationHint(types = {
+						FeatureDetector.class,
+						NativePathLocationScanner.class,
+						BufferedLogCreator.class
+				}, initTime = InitializationTime.BUILD)
+		},
+		types = {
+				@TypeHint(types = {Slf4jLogCreator.class})
+		},
+		resources = {
+				@ResourceHint(patterns = {"org/flywaydb/core/internal/version.txt"})
+		}
+)
+public class FlywayHints implements NativeConfiguration {
+}

--- a/spring-native-configuration/src/main/java/org/flywaydb/NativePathLocationScanner.java
+++ b/spring-native-configuration/src/main/java/org/flywaydb/NativePathLocationScanner.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flywaydb;
+
+import org.flywaydb.core.api.Location;
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogFactory;
+import org.flywaydb.core.api.resource.LoadableResource;
+import org.flywaydb.core.internal.resource.classpath.ClassPathResource;
+import org.flywaydb.core.internal.scanner.classpath.ResourceAndClassScanner;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class is used in order to prevent Flyway from doing classpath scanning which is both slow and won't work in
+ * native mode.
+ * <p>
+ * Forked from micronaut:
+ * https://github.com/micronaut-projects/micronaut-flyway/blob/758da7d56280f5b923b2e09a1849e82974679e64/flyway/src/main/java/io/micronaut/flyway/graalvm/MicronautPathLocationScanner.java
+ * <p>
+ * Forked from Quarkus:
+ * https://github.com/quarkusio/quarkus/blob/7a5efed2a97d88656484b431b472210e2bb7d2f3/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/QuarkusPathLocationScanner.java
+ */
+@SuppressWarnings("rawtypes")
+public final class NativePathLocationScanner implements ResourceAndClassScanner {
+
+		private static final Log LOG = LogFactory.getLog(NativePathLocationScanner.class);
+
+		private static final String LOCATION_SEPARATOR = "/";
+		private static List<String> applicationMigrationFiles;
+
+		private final Collection<LoadableResource> scannedResources;
+
+		public NativePathLocationScanner(Collection<Location> locations) {
+				this.scannedResources = new ArrayList<>();
+				ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+				for (String migrationFile : applicationMigrationFiles) {
+						if (canHandleMigrationFile(locations, migrationFile)) {
+								LOG.debug("Loading " + migrationFile);
+								scannedResources.add(new ClassPathResource(null, migrationFile, classLoader, StandardCharsets.UTF_8));
+						}
+				}
+		}
+
+		@Override
+		public Collection<LoadableResource> scanForResources() {
+				return scannedResources;
+		}
+
+		@Override
+		public Collection<Class<?>> scanForClasses() {
+				// Classes are not supported in native mode
+				return Collections.emptyList();
+		}
+
+		public static void setApplicationMigrationFiles(List<String> applicationMigrationFiles) {
+				NativePathLocationScanner.applicationMigrationFiles = applicationMigrationFiles;
+		}
+
+		private boolean canHandleMigrationFile(Collection<Location> locations, String migrationFile) {
+				for (Location location : locations) {
+						String locationPath = location.getPath();
+						if (!locationPath.endsWith(LOCATION_SEPARATOR)) {
+								locationPath += "/";
+						}
+
+						if (migrationFile.startsWith(locationPath)) {
+								return true;
+						} else {
+								LOG.debug("Migration file '" + migrationFile + "' will be ignored because it does not start with '" + locationPath + "'");
+						}
+				}
+
+				return false;
+		}
+}

--- a/spring-native-configuration/src/main/java/org/flywaydb/ScannerSubstitutions.java
+++ b/spring-native-configuration/src/main/java/org/flywaydb/ScannerSubstitutions.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flywaydb;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.flywaydb.core.api.Location;
+import org.flywaydb.core.api.resource.LoadableResource;
+import org.flywaydb.core.internal.scanner.LocationScannerCache;
+import org.flywaydb.core.internal.scanner.ResourceNameCache;
+import org.flywaydb.core.internal.scanner.classpath.ResourceAndClassScanner;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * This substitution replaces the Flyway dynamic scanners with a fixed path scanner in native mode.
+ * <p>
+ * Forked from micronaut:
+ * https://github.com/micronaut-projects/micronaut-flyway/blob/758da7d56280f5b923b2e09a1849e82974679e64/flyway/src/main/java/io/micronaut/flyway/graalvm/ScannerSubstitutions.java
+ * <p>
+ * Which was forked from Quarkus:
+ * https://github.com/quarkusio/quarkus/blob/2c99a30985e7cae42933b949ecd2ee82d546c4aa/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/ScannerSubstitutions.java
+ */
+@TargetClass(className = "org.flywaydb.core.internal.scanner.Scanner")
+public final class ScannerSubstitutions {
+
+		@Alias
+		private List<LoadableResource> resources = new ArrayList<>();
+
+		@Alias
+		private List<Class<?>> classes = new ArrayList<>();
+
+		@Alias
+		private HashMap<String, LoadableResource> relativeResourceMap = new HashMap<>();
+
+		/**
+		 * Creates only {@link org.flywaydb.NativePathLocationScanner} instances.
+		 * Replaces the original method that tries to detect migrations using reflection techniques that are not allowed
+		 * in native mode.
+		 *
+		 * @see org.flywaydb.core.internal.scanner.Scanner#Scanner(Class, Collection, ClassLoader, Charset, boolean, boolean, ResourceNameCache, LocationScannerCache, boolean)
+		 */
+		@Substitute
+		public ScannerSubstitutions(
+				Class<?> implementedInterface,
+				Collection<Location> locations,
+				ClassLoader classLoader,
+				Charset encoding,
+				boolean detectEncoding,
+				boolean stream,
+				ResourceNameCache resourceNameCache,
+				LocationScannerCache locationScannerCache,
+				boolean throwOnMissingLocations) {
+				ResourceAndClassScanner scanner = new NativePathLocationScanner(locations);
+
+				Collection resources = scanner.scanForResources();
+				this.resources.addAll(resources);
+
+				Collection scanForClasses = scanner.scanForClasses();
+				classes.addAll(scanForClasses);
+
+				for (LoadableResource resource : this.resources) {
+						relativeResourceMap.put(resource.getRelativePath().toLowerCase(), resource);
+				}
+		}
+}


### PR DESCRIPTION
This commit contains the adjustments that were made in micronaut and
quarkus to use flyway in native binaries.

The files were copied/took over from the micronaut repository which
copied/took over the files from quarkus.

A minor adjustment was made to use the flyways logger factory instead of
slf4j.

The micronaut repository with the sources can be found here:
https://github.com/micronaut-projects/micronaut-flyway/

The quarkus repository with the sources can be found here:
https://github.com/quarkusio/quarkus/tree/main/extensions/flyway/

The location of flyway scripts can be customized by adding the
flyway.locations property to the buildArgs of the native build
maven/gradle task. It is recognized at build time:

```
nativeBuild {
  ...
  buildArgs.set(listOf(
    "-Dflyway.locations=classpath:db/migration/postgres"))
}
```

---
I am not sure if the location of the files is correct as it contains classes with
@Substitute/@Alias annotations. I haven't found them in the spring-native-configuration repository.
I haven't tested the files after copying them from my test project to this repo. Is it possible to use the build results of the PR build to test the change in a demo application? Or is there another way of testing it without configuring the maven-publish plugin in the spring-native-configuration repository?

---
I have copied the files from micronaut and did small adjustments as described above.
I've removed the `@author` and `@since` annotations from the javadoc as this relates probably mainly to the micronaut changes (at least partially they are identical to the ones in the quarkus repository). I'm not sure whether they have to be kept or whether it's sufficient to have the links to the files in the other repos in the javadoc.

Additionally I had the impression that the latest quarkus version is a little bit different. With the latest changes from the quarkus repo i couldn't start the application successfully (initially they probably had something more similar to the micronaut solution).
The changes that were taken over from micronaut are working successfully in my sample application.

The sample application can be found here:
https://github.com/cschaible/spring-native-intro-samples/tree/master/csc.native.jpa

The docker containers can be started by running the `docker/up.sh` script.
The application can be built by running `./gradlew clean nativeBuild`.
The binary can be started by running: `SPRING_PROFILES_ACTIVE=postgres ./csc.native.jpa`.

---
Please add comments if you have refactoring wishes or feel free to adjust the code yourself.