### PR TITLE
Do not add reflection configuration for java.time types via RepositoryDefinitionConfigurationProcessor

### DIFF
--- a/spring-aot/src/main/java/org/springframework/data/RepositoryDefinitionConfigurationProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/data/RepositoryDefinitionConfigurationProcessor.java
@@ -301,9 +301,7 @@ public class RepositoryDefinitionConfigurationProcessor implements BeanFactoryNa
 					return;
 				}
 				if (SimpleTypeHolder.DEFAULT.isSimpleType(domainType.getType())) { // eg. String, ...
-					if (!domainType.isPartOf("java.time")) { // ES auditing using Instant
-						return;
-					}
+					return;
 				}
 				Builder reflectBuilder = registry.reflection().forType(domainType.getType()).withFlags();
 				if (domainType.hasMethods()) {

--- a/spring-aot/src/test/java/org/springframework/data/RepositoryDefinitionConfigurationProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/data/RepositoryDefinitionConfigurationProcessorTests.java
@@ -96,6 +96,7 @@ public class RepositoryDefinitionConfigurationProcessorTests {
 				.contains(CustomerRepository.class) // Repository Interface
 				.contains(BaseEntity.class, Customer.class, Address.class, LocationHolder.class) // User Domain Types
 				.doesNotContain(Point.class) // Spring Data Domain Types
+				.doesNotContain(Instant.class) // Types considered simple ones
 				.contains(TypeAlias.class, Id.class, Persistent.class, Transient.class, PersistenceConstructor.class) // Spring Data Annotations
 				.doesNotContain(Documented.class) // java.lang Annotations
 				.doesNotContain(Component.class); // Spring Stereotype Annotations
@@ -108,6 +109,7 @@ public class RepositoryDefinitionConfigurationProcessorTests {
 				.contains(CustomerRepositoryReactive.class) // Repository Interface
 				.contains(BaseEntity.class, Customer.class, Address.class, LocationHolder.class) // User Domain Types
 				.doesNotContain(Point.class) // Spring Data Domain Types
+				.doesNotContain(Instant.class) // Types considered simple ones
 				.contains(TypeAlias.class, Id.class, Persistent.class, Transient.class, PersistenceConstructor.class) // Spring Data Annotations
 				.doesNotContain(Documented.class) // java.lang Annotations
 				.doesNotContain(Component.class); // Spring Stereotype Annotations
@@ -150,8 +152,8 @@ public class RepositoryDefinitionConfigurationProcessorTests {
 				.contains(CustomImplInterface2Impl.class) // Fragment 1 Implementation target
 				.contains(DomainObjectWithSimpleTypesOnly.class) // Domain Type Repository Interface
 				.contains(BaseEntity.class, Customer.class, Address.class, LocationHolder.class) // Domain Types Custom Implementation
-				.contains(Instant.class) // java.time
 				.contains(TypeAlias.class, Id.class, Persistent.class, Transient.class, PersistenceConstructor.class, LastModifiedDate.class) // Spring Data Annotations
+				.doesNotContain(Instant.class) // java.time
 				.doesNotContain(Documented.class) // java.lang Annotations
 				.doesNotContain(Component.class); // Spring Stereotype Annotations
 	}


### PR DESCRIPTION
Spring Data Elasticsearch now no longer uses reflection on `java.time` types, which allows us to remove the special treatment for those.

Resolves: #1205 