### PR TITLE
Only @Component are considered for JPA configuration processing

### DIFF
--- a/spring-aot/src/main/java/org/springframework/data/JpaConfigurationProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/data/JpaConfigurationProcessor.java
@@ -83,14 +83,13 @@ public class JpaConfigurationProcessor implements BeanFactoryNativeConfiguration
 	static class JpaPersistenceContextProcessor {
 
 		void process(ConfigurableListableBeanFactory beanFactory, NativeConfigurationRegistry registry) {
-			doWithComponents(beanFactory,
+
+			new BeanFactoryProcessor(beanFactory).processBeans(
+					(beanType) -> TypeUtils.hasAnnotatedField(beanType, JPA_PERSISTENCE_CONTEXT),
 					(beanName, beanType) -> {
 						registry.reflection()
 								.forType(beanType)
 								.withFields(TypeUtils.getAnnotatedField(beanType, JPA_PERSISTENCE_CONTEXT).toArray(new Field[0]));
-					},
-					(beanName, beanType) -> {
-						return TypeUtils.hasAnnotatedField(beanType, JPA_PERSISTENCE_CONTEXT);
 					});
 		}
 	}
@@ -138,7 +137,8 @@ public class JpaConfigurationProcessor implements BeanFactoryNativeConfiguration
 				return;
 			}
 
-			doWithComponents(beanFactory,
+			new BeanFactoryProcessor(beanFactory).processBeans(
+					(beanType) -> MergedAnnotations.from(beanType).isPresent("org.springframework.boot.autoconfigure.domain.EntityScan"),
 					(beanName, beanType) -> {
 
 						MergedAnnotation<Annotation> entityScanAnnotation = MergedAnnotations.from(beanType).get("org.springframework.boot.autoconfigure.domain.EntityScan");
@@ -153,9 +153,6 @@ public class JpaConfigurationProcessor implements BeanFactoryNativeConfiguration
 							}
 						}
 						process(resolvedTypes, registry);
-					},
-					(beanName, beanType) -> {
-						return MergedAnnotations.from(beanType).isPresent("org.springframework.boot.autoconfigure.domain.EntityScan");
 					});
 		}
 
@@ -323,14 +320,4 @@ public class JpaConfigurationProcessor implements BeanFactoryNativeConfiguration
 		}
 		return null;
 	}
-
-	static void doWithComponents(ConfigurableListableBeanFactory beanFactory, NativeConfigurationUtils.ComponentCallback callback,
-			NativeConfigurationUtils.ComponentFilter filter) {
-		new BeanFactoryProcessor(beanFactory).processBeansWithAnnotation(Component.class, (beanName, beanType) -> {
-			if (filter == null || filter.test(beanName, beanType)) {
-				callback.invoke(beanName, beanType);
-			}
-		});
-	}
-
 }

--- a/spring-aot/src/test/java/org/springframework/aot/support/BeanFactoryProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/aot/support/BeanFactoryProcessorTests.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.samples.scan.ScanConfiguration;
 import org.springframework.context.annotation.samples.simple.ConfigurationOne;
 import org.springframework.context.annotation.samples.simple.ConfigurationTwo;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.entry;
  * Tests for {@link BeanFactoryProcessor}.
  *
  * @author Stephane Nicoll
+ * @author Christoph Strobl
  */
 class BeanFactoryProcessorTests {
 
@@ -86,6 +88,13 @@ class BeanFactoryProcessorTests {
 				entry("configurationTwo", ConfigurationTwo.class));
 	}
 
+	@Test
+	void processWithFilter() {
+		ListableBeanFactory beanFactory = prepare(ConfigurationOne.class);
+		ConsumerCollector consumer = new ConsumerCollector();
+		new BeanFactoryProcessor(beanFactory).processBeans(type -> AnnotatedElementUtils.isAnnotated(type, Configuration.class), consumer);
+		assertThat(consumer.callbacks).containsOnly(entry("configurationOne", ConfigurationOne.class));
+	}
 
 	private ListableBeanFactory prepare(Class<?>... candidates) {
 		GenericApplicationContext context = new AnnotationConfigApplicationContext();


### PR DESCRIPTION
This commit removes the limitation of scanning only for beans annotated with `@Component` when resolving jpa specific configuration.