### PR TITLE
Add configuration for Spring Data MongoDB DocumentReference annotation.

### DIFF
--- a/samples/data-mongodb/src/main/java/com/example/data/mongo/CLR.java
+++ b/samples/data-mongodb/src/main/java/com/example/data/mongo/CLR.java
@@ -225,7 +225,25 @@ public class CLR implements CommandLineRunner {
 		}
 
 		{
+			System.out.println("---- Document References ----");
+			orderRepository.deleteAll();
+			Discount discount = new Discount(30F);
+			template.insert(discount);
 
+			Order order = new Order("c42", new Date()).//
+					addItem(product1).addItem(product2).addItem(product3);
+			order.setDocumentRef(discount);
+			order.setLazyDocumentRef(discount);
+
+			orderRepository.save(order);
+
+			Optional<Order> loaded = orderRepository.findById(order.getId());
+			System.out.println("document ref (no proxy): " + loaded.get().getDocumentRef().getPercentage());
+			System.out.println("lazy document ref (aot): " + loaded.get().lazyDocumentRef);
+			System.out.println("-----------------\n\n\n");
+		}
+
+		{
 			System.out.println("---- QUERY BY EXAMPLE ----");
 			orderRepository.deleteAll();
 

--- a/samples/data-mongodb/src/main/java/com/example/data/mongo/Discount.java
+++ b/samples/data-mongodb/src/main/java/com/example/data/mongo/Discount.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.mongo;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class Discount implements PriceReduction {
+
+	private @Id String id;
+	private Float percentage;
+
+	public Discount(Float percentage) {
+		this.percentage = percentage;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Float getPercentage() {
+		return percentage;
+	}
+
+	public void setPercentage(Float percentage) {
+		this.percentage = percentage;
+	}
+}

--- a/samples/data-mongodb/src/main/java/com/example/data/mongo/Order.java
+++ b/samples/data-mongodb/src/main/java/com/example/data/mongo/Order.java
@@ -28,6 +28,7 @@ import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document
@@ -51,6 +52,12 @@ public class Order {
 
 	@DBRef(lazy = true) // JdkProxy
 	private PriceReduction reduction;
+
+	@DocumentReference
+	private Discount documentRef;
+
+	@DocumentReference(lazy = true)
+	Discount lazyDocumentRef;
 
 	@CreatedDate
 	Instant createdAt;
@@ -153,6 +160,22 @@ public class Order {
 
 	public void setSimpleRef(Coupon simpleRef) {
 		this.simpleRef = simpleRef;
+	}
+
+	public Discount getDocumentRef() {
+		return documentRef;
+	}
+
+	public void setDocumentRef(Discount documentRef) {
+		this.documentRef = documentRef;
+	}
+
+	public Discount getLazyDocumentRef() {
+		return lazyDocumentRef;
+	}
+
+	public void setLazyDocumentRef(Discount lazyDocumentRef) {
+		this.lazyDocumentRef = lazyDocumentRef;
 	}
 
 	@Override

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/mongodb/MongoRepositoriesHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/data/mongodb/MongoRepositoriesHints.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.boot.autoconfigure.data.SpringDataReactiveHints;
 import org.springframework.boot.autoconfigure.data.mongo.MongoReactiveRepositoriesAutoConfiguration;
@@ -92,43 +93,58 @@ public class MongoRepositoriesHints implements NativeConfiguration {
 			return Collections.emptyList();
 		}
 
-		List<Type> scan = typeSystem.scan(type -> !type.getFieldsWithAnnotation("Lorg/springframework/data/mongodb/core/mapping/DBRef;", false).isEmpty());
+		List<Type> scan = typeSystem.scan(type -> {
+			return !type.getFieldsWithAnnotation("Lorg/springframework/data/mongodb/core/mapping/DBRef;", false).isEmpty() &&
+					!type.getFieldsWithAnnotation("Lorg/springframework/data/mongodb/core/mapping/DocumentReference;", false).isEmpty();
+		});
 		List<HintDeclaration> hints = scan.stream()
 				.flatMap(type -> {
-					return type.getFieldsWithAnnotation("Lorg/springframework/data/mongodb/core/mapping/DBRef;", false)
-							.stream()
-							.filter(field -> {
-										if (field == null) {
-											return false;
-										}
-										Map<String, String> annotationValuesInHierarchy = field.getAnnotationValuesInHierarchy("Lorg/springframework/data/mongodb/core/mapping/DBRef;");
-										return annotationValuesInHierarchy.get("lazy") == "true";
-									}
-							)
-							.map(field -> {
-
-								if (field.getType().isInterface()) {
-
-									HintDeclaration hintDeclaration = new HintDeclaration();
-									List<String> interfaces = new ArrayList<>(field.getSignature().stream().map(typeSystem::resolveSlashed).map(Type::getDottedName).collect(Collectors.toList()));
-									interfaces.add(0, "org.springframework.data.mongodb.core.convert.LazyLoadingProxy");
-									interfaces.add("org.springframework.aop.SpringProxy");
-									interfaces.add("org.springframework.aop.framework.Advised");
-									interfaces.add("org.springframework.core.DecoratingProxy");
-
-									JdkProxyDescriptor descriptor = new JdkProxyDescriptor(interfaces);
-									hintDeclaration.addProxyDescriptor(descriptor);
-									return hintDeclaration;
-								}
-
-								HintDeclaration hintDeclaration = new HintDeclaration();
-								AotProxyDescriptor descriptor = new AotProxyDescriptor(field.getType().getDottedName(), Collections.singletonList("org.springframework.data.mongodb.core.convert.LazyLoadingProxy"), ProxyBits.IS_STATIC);
-								hintDeclaration.addProxyDescriptor(descriptor);
-								return hintDeclaration;
-							});
+					return computeAssociations(typeSystem, type);
 				}).collect(Collectors.toList());
 
-		System.out.println("MongoDBRef proxies: " + hints);
 		return hints;
+	}
+
+	private Stream<HintDeclaration> computeAssociations(TypeSystem typeSystem, Type type) {
+		return Stream.concat(
+					computeAssociations(typeSystem, type, "Lorg/springframework/data/mongodb/core/mapping/DBRef;"),
+					computeAssociations(typeSystem, type, "Lorg/springframework/data/mongodb/core/mapping/DocumentReference;")
+				);
+	}
+
+	private Stream<HintDeclaration> computeAssociations(TypeSystem typeSystem, Type type, String annotation) {
+
+		return type.getFieldsWithAnnotation(annotation, false)
+
+				.stream()
+				.filter(field -> {
+							if (field == null) {
+								return false;
+							}
+							Map<String, String> annotationValuesInHierarchy = field.getAnnotationValuesInHierarchy(annotation);
+							return annotationValuesInHierarchy.get("lazy") == "true";
+						}
+				)
+				.map(field -> {
+
+					if (field.getType().isInterface()) {
+
+						HintDeclaration hintDeclaration = new HintDeclaration();
+						List<String> interfaces = new ArrayList<>(field.getSignature().stream().map(typeSystem::resolveSlashed).map(Type::getDottedName).collect(Collectors.toList()));
+						interfaces.add(0, "org.springframework.data.mongodb.core.convert.LazyLoadingProxy");
+						interfaces.add("org.springframework.aop.SpringProxy");
+						interfaces.add("org.springframework.aop.framework.Advised");
+						interfaces.add("org.springframework.core.DecoratingProxy");
+
+						JdkProxyDescriptor descriptor = new JdkProxyDescriptor(interfaces);
+						hintDeclaration.addProxyDescriptor(descriptor);
+						return hintDeclaration;
+					}
+
+					HintDeclaration hintDeclaration = new HintDeclaration();
+					AotProxyDescriptor descriptor = new AotProxyDescriptor(field.getType().getDottedName(), Collections.singletonList("org.springframework.data.mongodb.core.convert.LazyLoadingProxy"), ProxyBits.IS_STATIC);
+					hintDeclaration.addProxyDescriptor(descriptor);
+					return hintDeclaration;
+				});
 	}
 }


### PR DESCRIPTION
This PR makes sure to register required proxies and configuration for fields annotated with `@DocumentReference`.