### PR TITLE
Generate Avro types for all @KafkaListener-annotated beans

### DIFF
--- a/samples/kafka-avro/src/main/java/com/example/kafka/KafkaAvroApplication.java
+++ b/samples/kafka-avro/src/main/java/com/example/kafka/KafkaAvroApplication.java
@@ -41,7 +41,8 @@ public class KafkaAvroApplication {
 	}
 
 	@Bean
-	public ConcurrentMessageListenerContainer<Object, Object> manualListenerContainer(MyMessageListener listener,
+	public ConcurrentMessageListenerContainer<Object, Object> manualListenerContainer(
+			NotAComponentMessageListener listener,
 			ConcurrentKafkaListenerContainerFactory<Object, Object> factory) {
 
 		factory.setCommonErrorHandler(new CommonContainerStoppingErrorHandler());
@@ -49,6 +50,11 @@ public class KafkaAvroApplication {
 		container.getContainerProperties().setGroupId("graal3");
 		container.getContainerProperties().setMessageListener(listener);
 		return container;
+	}
+
+	@Bean
+	NotAComponentMessageListener otherListner() {
+		return new NotAComponentMessageListener();
 	}
 
 	@Bean
@@ -82,8 +88,7 @@ class RecordListener {
 
 }
 
-@Component
-class MyMessageListener implements MessageListener<String, Thing3> {
+class NotAComponentMessageListener implements MessageListener<String, Thing3> {
 
 	@Override
 	public void onMessage(ConsumerRecord<String, Thing3> record) {

--- a/samples/kafka-avro/verify.sh
+++ b/samples/kafka-avro/verify.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 source ${PWD%/*samples/*}/scripts/wait.sh
-wait_log target/native/test-output.txt "++++++Received Thing"
+wait_log target/native/test-output.txt "++++++Received Thing3"

--- a/spring-aot/src/test/java/org/springframework/kafka/KafkaAvroNativeConfigurationProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/kafka/KafkaAvroNativeConfigurationProcessorTests.java
@@ -121,6 +121,19 @@ public class KafkaAvroNativeConfigurationProcessorTests {
 		assertThat(entries).hasSize(2);
 	}
 
+	@Test
+	void notAComponent() {
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("noise", BeanDefinitionBuilder.rootBeanDefinition(String.class)
+				.getBeanDefinition());
+		beanFactory.registerBeanDefinition("myListener", BeanDefinitionBuilder
+				.rootBeanDefinition(NotAComponentListener5.class)
+				.getBeanDefinition());
+		NativeConfigurationRegistry registry = process(beanFactory);
+		assertThat(registry.reflection().reflectionEntries()).singleElement().satisfies((entry) ->
+				assertThat(entry.getType()).isSameAs(AvroType3.class));
+	}
+
 	private NativeConfigurationRegistry process(DefaultListableBeanFactory beanFactory) {
 		NativeConfigurationRegistry registry = new NativeConfigurationRegistry();
 		new KafkaAvroNativeConfigurationProcessor().process(beanFactory, registry);
@@ -172,12 +185,24 @@ public class KafkaAvroNativeConfigurationProcessorTests {
 
 	}
 
+	static class NotAComponentListener5 {
+
+		@KafkaListener
+		void listen(AvroType3 avro) {
+		}
+
+	}
+
 	@AvroGenerated
 	private static final class AvroType1 {
 	}
 
 	@AvroGenerated
 	private static final class AvroType2 {
+	}
+
+	@AvroGenerated
+	private static final class AvroType3 {
 	}
 
 }


### PR DESCRIPTION
Previously, Apache Avro types for `@KafkaListener` classes or
methods were only detected for beans annotated with `@Component`.

Listener beans can also be simply declared as `@Bean` and don't need
`@Component`.