### PR TITLE
GH-1134: Restore Spring Integration support

### DIFF
--- a/samples/integration/pom.xml
+++ b/samples/integration/pom.xml
@@ -17,6 +17,7 @@
 
 	<properties>
 		<java.version>11</java.version>
+		<spring-integration.version>5.5.7-SNAPSHOT</spring-integration.version>
 	</properties>
 
 	<dependencies>
@@ -74,5 +75,53 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>windows</id>
+			<activation>
+				<os>
+					<family>Windows</family>
+				</os>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.2.4</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<shadedArtifactAttached>true</shadedArtifactAttached>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>${native.buildtools.version}</version>
+						<configuration>
+							<skip>false</skip>
+							<imageName>${project.artifactId}</imageName>
+							<mainClass>${exec.mainClass}</mainClass>
+							<buildArgs>
+								<buildArg>--no-fallback</buildArg>
+							</buildArgs>
+							<classpath>
+								<param>${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar</param>
+							</classpath>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/integration/IntegrationHints.java
@@ -66,12 +66,28 @@ import org.springframework.nativex.type.TypeSystemNativeConfiguration;
 						}),
 				@TypeHint(access = AccessBits.CLASS | AccessBits.PUBLIC_METHODS,
 						types = {
+								org.springframework.beans.factory.config.BeanExpressionContext.class,
+								org.springframework.integration.config.ConsumerEndpointFactoryBean.class,
+								org.springframework.integration.context.IntegrationContextUtils.class,
 								org.springframework.integration.xml.xpath.XPathUtils.class,
 								org.springframework.integration.json.JsonPathUtils.class,
 								com.jayway.jsonpath.JsonPath.class,
 								org.springframework.integration.gateway.MethodArgsHolder.class,
 								org.springframework.integration.routingslip.ExpressionEvaluatingRoutingSlipRouteStrategy.RequestAndReply.class,
-								org.springframework.integration.core.Pausable.class
+								org.springframework.integration.core.Pausable.class,
+								org.springframework.integration.annotation.ServiceActivator.class,
+								org.springframework.integration.annotation.Splitter.class,
+								org.springframework.integration.annotation.Transformer.class,
+								org.springframework.integration.annotation.Router.class,
+								org.springframework.integration.annotation.Filter.class,
+								org.springframework.integration.annotation.BridgeFrom.class,
+								org.springframework.integration.annotation.BridgeTo.class,
+								org.springframework.integration.annotation.Aggregator.class,
+								org.springframework.integration.annotation.Gateway.class,
+								org.springframework.integration.annotation.GatewayHeader.class,
+								org.springframework.integration.annotation.InboundChannelAdapter.class,
+								org.springframework.integration.annotation.Poller.class,
+								org.springframework.integration.annotation.Publisher.class
 						})
 		},
 		serializables = {
@@ -127,7 +143,6 @@ import org.springframework.nativex.type.TypeSystemNativeConfiguration;
 		@TypeHint(
 				types = {
 						org.springframework.integration.core.GenericSelector.class,
-						org.springframework.messaging.support.GenericMessage.class,
 						org.springframework.integration.transformer.GenericTransformer.class,
 						org.springframework.integration.handler.GenericHandler.class,
 						java.util.function.Function.class,
@@ -187,8 +202,7 @@ public class IntegrationHints implements NativeConfiguration, TypeSystemNativeCo
 		hints.addAll(computeMessagingGatewayHints(typeSystem));
 		hints.addAll(computeAbstractEndpointHints(typeSystem));
 		hints.addAll(computeIntegrationNodeHints(typeSystem));
-		//		TODO Fails with 'Unable to find class file for org/springframework/web/server/WebFilter' on 'spring-aot-maven-plugin:test-generate'
-		//		hints.addAll(computeMessageHints(typeSystem));
+		hints.addAll(computeMessageHints(typeSystem));
 		return hints;
 	}
 
@@ -244,7 +258,7 @@ public class IntegrationHints implements NativeConfiguration, TypeSystemNativeCo
 				.skipMethodInspection()
 				.skipFieldInspection()
 				.skipConstructorInspection()
-				.filter(type -> type.implementsInterface(MESSAGE_TYPE))
+				.filter(type -> type.implementsInterface(MESSAGE_TYPE, true))
 				.onTypeDiscovered((type, context) ->
 						context.addReflectiveAccess(type,
 								new AccessDescriptor(AccessBits.CLASS | AccessBits.PUBLIC_METHODS)))


### PR DESCRIPTION
Fixes https://github.com/spring-projects-experimental/spring-native/issues/1134

* Upgrade sample to the latest Spring Integration `5.5.7-SNAPSHOT`
* Add `maven-shade-plugin` and `native-maven-plugin` under Windows profile
to make native image build working on Windows.
Se more info in Native Build Tools docs:
https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#long_classpath_and_shading_support
This profile simply can go to the `../maven-parent/pom.xml` to make all the samples working on Windows.
Or you can remove this on merge since it might be just a noise for a broader community
* Add custom `ReactorClientHttpConnector` bean into the sample app, since by default a DNS resolver
fails with NPE on Windows in native image.
See more info in the: https://github.com/spring-projects/spring-framework/issues/27749
* Add more type nints into the `IntegrationHints`