### PR TITLE
Register reflection configuration for JPA AttributeConverter implementations

### DIFF
--- a/spring-aot/src/main/java/org/springframework/data/JpaConfigurationProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/data/JpaConfigurationProcessor.java
@@ -151,6 +151,10 @@ public class JpaConfigurationProcessor implements BeanFactoryNativeConfiguration
 			TypeModelProcessor typeModelProcessor = new TypeModelProcessor();
 			entities.forEach(type -> {
 
+				if(TypeUtils.type(type).isPartOf("java") || type.isPrimitive() || ClassUtils.isPrimitiveArray(type)) {
+					return;
+				}
+
 				/*
 				 * If an EntityListener is defined we need to inspect the target and make sure
 				 * reflection is configured so the methods can be invoked
@@ -168,6 +172,10 @@ public class JpaConfigurationProcessor implements BeanFactoryNativeConfiguration
 				 * Final fields require special treatment having allowWrite set.
 				 */
 				typeModelProcessor.inspect(type).forEach(typeModel -> {
+
+					if(typeModel.isPartOf("java") || typeModel.isPrimitiveType()) {
+						return;
+					}
 
 					DefaultNativeReflectionEntry.Builder builder = registry.reflection().forType(typeModel.getType());
 					builder.withAccess(TypeAccess.DECLARED_FIELDS, TypeAccess.DECLARED_METHODS, TypeAccess.DECLARED_CONSTRUCTORS);

--- a/spring-aot/src/main/java/org/springframework/data/TypeModel.java
+++ b/spring-aot/src/main/java/org/springframework/data/TypeModel.java
@@ -134,6 +134,10 @@ public class TypeModel { // TODO: implements TypeInformation
 		return !ObjectUtils.isEmpty(type.getDeclaredClasses());
 	}
 
+	public boolean isPrimitiveType() {
+		return type.isPrimitive() || ClassUtils.isPrimitiveArray(type);
+	}
+
 	@Nullable
 	public Constructor getPersistenceConstructor() {
 

--- a/spring-aot/src/test/java/org/springframework/data/JpaConfigurationProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/data/JpaConfigurationProcessorTests.java
@@ -18,6 +18,7 @@ package org.springframework.data;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -39,7 +40,9 @@ import org.springframework.nativex.domain.reflect.FieldDescriptor;
 import org.springframework.nativex.hint.TypeAccess;
 import org.springframework.sample.data.jpa.AuditingListener;
 import org.springframework.sample.data.jpa.ComponentWithPersistenceContext;
+import org.springframework.sample.data.jpa.EntityWithClassField;
 import org.springframework.sample.data.jpa.EntityWithListener;
+import org.springframework.sample.data.jpa.EntityWithPrimitive;
 import org.springframework.sample.data.jpa.LineItem;
 import org.springframework.sample.data.jpa.NotAnEntity;
 import org.springframework.sample.data.jpa.Order;
@@ -156,6 +159,24 @@ public class JpaConfigurationProcessorTests {
 		});
 	}
 
+	@Test
+	public void shouldNotRegisterJavaLangTypes() {
+
+		assertThat(processJpaEntities(EntityWithClassField.class).reflectionEntries())
+				.map(DefaultNativeReflectionEntry::getType)
+				.map(Class.class::cast)
+				.doesNotContain(Class.class);
+	}
+
+	@Test
+	public void shouldNotRegisterPrimitiveTypes() {
+
+		assertThat(processJpaEntities(EntityWithPrimitive.class).reflectionEntries())
+				.map(DefaultNativeReflectionEntry::getType)
+				.map(Class.class::cast)
+				.doesNotContain(int.class, byte[].class);
+	}
+
 	private Class<?> createCglibProxyType(Class<?> target) {
 		ProxyFactory proxyFactory = new ProxyFactory();
 		proxyFactory.setTargetClass(target);
@@ -194,6 +215,10 @@ public class JpaConfigurationProcessorTests {
 
 		boolean hasReflectionEntry(Class<?> type) {
 			return delegate.reflection().reflectionEntries().anyMatch(it -> it.getType().equals(type));
+		}
+
+		public Stream<DefaultNativeReflectionEntry> reflectionEntries() {
+			return delegate.reflection().reflectionEntries();
 		}
 	}
 }

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithClassField.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithClassField.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class EntityWithClassField {
+
+	@Id @GeneratedValue
+	private Long id;
+	Class<?> type;
+
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithPrimitive.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/EntityWithPrimitive.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class EntityWithPrimitive {
+
+	@Id
+	Long id;
+	byte[] byteArr;
+	int primInt;
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/ValueObjectId.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/ValueObjectId.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+public class ValueObjectId {
+	String id;
+
+	public ValueObjectId(String id) {
+		this.id = id;
+	}
+}

--- a/spring-aot/src/test/java/org/springframework/sample/data/jpa/ValueObjectIdAttributeConverter.java
+++ b/spring-aot/src/test/java/org/springframework/sample/data/jpa/ValueObjectIdAttributeConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sample.data.jpa;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class ValueObjectIdAttributeConverter implements AttributeConverter<ValueObjectId, String> {
+
+	@Override
+	public String convertToDatabaseColumn(ValueObjectId attribute) {
+		return attribute.id;
+	}
+
+	@Override
+	public ValueObjectId convertToEntityAttribute(String dbData) {
+		return new ValueObjectId(dbData);
+	}
+}


### PR DESCRIPTION
This commit makes sure to look up `@Converter` annotated `AttributeConverter` implementations within the base packages and adds required reflection configuration for both the type itself as well as the conversion return type.

Depends on (includes): #1346