### PR TITLE
Refine Spring HATEOAS hints.

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/hateoas/config/HateoasHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/hateoas/config/HateoasHints.java
@@ -204,6 +204,13 @@ public class HateoasHints implements NativeConfiguration, TypeSystemNativeConfig
 					return annotation.isPartOfDomain("org.springframework") ||
 							annotation.isPartOfDomain("com.fasterxml.jackson.annotation");
 				})
+				.onTypeDiscovered((type, ctx) -> {
+					if(type.belongsToPackage("java", true)) {
+						ctx.addReflectiveAccess(type, TypeAccess.RESOURCE);
+					} else {
+						ctx.addReflectiveAccess(type, TypeAccess.PUBLIC_METHODS, TypeAccess.PUBLIC_CONSTRUCTORS, TypeAccess.DECLARED_FIELDS);
+					}
+				})
 				.use(typeSystem)
 				.toProcessTypesMatching(type -> {
 

--- a/spring-native-configuration/src/test/java/com/example/test/hateoas/Drink.java
+++ b/spring-native-configuration/src/test/java/com/example/test/hateoas/Drink.java
@@ -17,4 +17,5 @@ package com.example.test.hateoas;
 
 public class Drink {
 
+	String name;
 }

--- a/spring-native-configuration/src/test/java/org/springframework/hateoas/config/HateoasHintsTests.java
+++ b/spring-native-configuration/src/test/java/org/springframework/hateoas/config/HateoasHintsTests.java
@@ -57,12 +57,13 @@ public class HateoasHintsTests {
 		List<HintDeclaration> hintDeclarations = hateoasHints.computeRepresentationModels(typeSystem);
 
 		assertHints(hintDeclarations)
-				.hasSize(4)
+				.hasSize(5)
 				.doesNotContainResourceConfiguration()
-				.extractReflectionConfigFor(PersonRepresentationModel.class, it -> it.hasAccessBits(FULL_REFLECTION))
-				.extractReflectionConfigFor(Person.class, it -> it.hasAccessBits(FULL_REFLECTION))
-				.extractReflectionConfigFor(DrinksModelProcessor.class, it -> it.hasAccessBits(FULL_REFLECTION))
-				.extractReflectionConfigFor(Drink.class, it -> it.hasAccessBits(FULL_REFLECTION));
+				.extractReflectionConfigFor(PersonRepresentationModel.class, it -> it.hasAccessBits(PUBLIC_METHODS | PUBLIC_CONSTRUCTORS | DECLARED_FIELDS))
+				.extractReflectionConfigFor(Person.class, it -> it.hasAccessBits(PUBLIC_METHODS | PUBLIC_CONSTRUCTORS | DECLARED_FIELDS))
+				.extractReflectionConfigFor(DrinksModelProcessor.class, it -> it.hasAccessBits(PUBLIC_METHODS | PUBLIC_CONSTRUCTORS | DECLARED_FIELDS))
+				.extractReflectionConfigFor(Drink.class, it -> it.hasAccessBits(PUBLIC_METHODS | PUBLIC_CONSTRUCTORS | DECLARED_FIELDS))
+				.extractReflectionConfigFor(String.class, it -> it.hasAccessBits(RESOURCE));
 	}
 
 	@Test


### PR DESCRIPTION
Make sure types from java namespace are only included with minimum reflection configuration.