### PR TITLE
Remove unnecessary null check

### DIFF
--- a/spring-aot/src/main/java/org/springframework/aot/factories/PrivateFactoriesCodeContributor.java
+++ b/spring-aot/src/main/java/org/springframework/aot/factories/PrivateFactoriesCodeContributor.java
@@ -46,7 +46,7 @@ class PrivateFactoriesCodeContributor implements FactoriesCodeContributor {
 		try {
 			Constructor<?> constructor = BeanUtils.getResolvableConstructor(factory);
 			return !Modifier.isPublic(factory.getModifiers()) ||
-					(constructor != null && constructor.getParameterCount() == 0 && !Modifier.isPublic(constructor.getModifiers()));
+					(constructor.getParameterCount() == 0 && !Modifier.isPublic(constructor.getModifiers()));
 		} catch (IllegalStateException | NoClassDefFoundError ex) {
 			return false;
 		}


### PR DESCRIPTION
The `BeanUtils#getResolvableConstructor()` does not return `null`.
This commit removes the unnecessary null check.

Signed-off-by: Tadaya Tsuyukubo <tadaya@ttddyy.net>