### PR TITLE
StackOverflowError when scanning hints for ConfigurationProperties with cross references

### DIFF
--- a/spring-aot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesNativeConfigurationProcessor.java
+++ b/spring-aot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesNativeConfigurationProcessor.java
@@ -99,6 +99,9 @@ class ConfigurationPropertiesNativeConfigurationProcessor implements BeanFactory
 		}
 
 		private void process(NativeConfigurationRegistry registry) {
+			if (registry.reflection().reflectionEntries().anyMatch(x -> x.getType() == this.type)) {
+				return;
+			}
 			Builder reflection = registry.reflection().forType(this.type);
 			if (isClassOnlyReflectionType()) {
 				return;

--- a/spring-aot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesNativeConfigurationProcessorTests.java
+++ b/spring-aot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesNativeConfigurationProcessorTests.java
@@ -235,6 +235,17 @@ class ConfigurationPropertiesNativeConfigurationProcessorTests {
 				.anySatisfy(classOnlyBinding(Environment.class)).hasSize(3);
 	}
 
+	@Test
+	void processConfigurationPropertiesWithCrossReference() {
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("beanA", BeanDefinitionBuilder.rootBeanDefinition(SamplePropertiesWithCrossReference.class).getBeanDefinition());
+		NativeConfigurationRegistry registry = process(beanFactory);
+		assertThat(registry.reflection().reflectionEntries())
+				.anySatisfy(javaBeanBinding(SamplePropertiesWithCrossReference.class))
+				.anySatisfy(javaBeanBinding(CrossReferenceA.class))
+				.anySatisfy(javaBeanBinding(CrossReferenceB.class)).hasSize(3);
+	}
+
 	private Consumer<DefaultNativeReflectionEntry> classOnlyBinding(Class<?> type) {
 		return (entry) -> {
 			assertThat(entry.getType()).isEqualTo(type);
@@ -521,6 +532,46 @@ class ConfigurationPropertiesNativeConfigurationProcessorTests {
 			this.recursive = recursive;
 		}
 
+	}
+
+
+	@ConfigurationProperties("crossReference")
+	static class SamplePropertiesWithCrossReference {
+
+		@NestedConfigurationProperty
+		private CrossReferenceA crossReferenceA;
+
+		public void setCrossReferenceA(CrossReferenceA crossReferenceA) {
+			this.crossReferenceA = crossReferenceA;
+		}
+
+		public CrossReferenceA getCrossReferenceA() {
+			return crossReferenceA;
+		}
+	}
+
+	static class CrossReferenceA {
+		private CrossReferenceB crossReferenceB;
+
+		public void setCrossReferenceB(CrossReferenceB crossReferenceB) {
+			this.crossReferenceB = crossReferenceB;
+		}
+
+		public CrossReferenceB getCrossReferenceB() {
+			return crossReferenceB;
+		}
+	}
+
+	static class CrossReferenceB {
+		private CrossReferenceA crossReferenceA;
+
+		public void setCrossReferenceA(CrossReferenceA crossReferenceA) {
+			this.crossReferenceA = crossReferenceA;
+		}
+
+		public CrossReferenceA getCrossReferenceA() {
+			return crossReferenceA;
+		}
 	}
 
 }


### PR DESCRIPTION
The current implementation occur the `StackOverflowError` when exists configuration properties bean that have cross reference property.  I want to avoid the `StackOverflowError`.


Note: [The properties class that provided by mybatis-spring-boot](https://github.com/mybatis/spring-boot-starter/blob/master/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java#L96) is this configuration (I understand it's not a good configuration..., but it's works on non-native Spring Boot).
