### PR TITLE
Fix factory name with spaces in "spring.factories"

### DIFF
--- a/spring-aot/src/main/java/org/springframework/aot/factories/SpringFactoriesContributor.java
+++ b/spring-aot/src/main/java/org/springframework/aot/factories/SpringFactoriesContributor.java
@@ -92,7 +92,7 @@ public class SpringFactoriesContributor implements BootstrapContributor {
 
 				for (String factoryName : factoryNames) {
 					logger.debug("Loading factory Impl:" + factoryName);
-					SpringFactory springFactory = SpringFactory.resolve(factoryTypeName, factoryName, buildContext.getClassLoader());
+					SpringFactory springFactory = SpringFactory.resolve(factoryTypeName, factoryName.trim(), buildContext.getClassLoader());
 					if (springFactory != null) {
 						factories.add(springFactory);
 					}

--- a/spring-aot/src/test/java/org/springframework/aot/factories/SpringFactoriesContributorTests.java
+++ b/spring-aot/src/test/java/org/springframework/aot/factories/SpringFactoriesContributorTests.java
@@ -1,0 +1,38 @@
+package org.springframework.aot.factories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.build.context.BuildContext;
+import org.springframework.aot.factories.fixtures.OtherFactory;
+import org.springframework.aot.factories.fixtures.PublicFactory;
+import org.springframework.aot.factories.fixtures.TestFactory;
+
+/**
+ * Tests for {@link SpringFactoriesContributor}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+class SpringFactoriesContributorTests {
+
+    SpringFactoriesContributor contributor = new SpringFactoriesContributor();
+
+    @Test
+    void shouldRecognizeEntryWithSpace() throws Exception {
+        BuildContext buildContext = mock(BuildContext.class);
+        when(buildContext.getClassLoader()).thenReturn(this.getClass().getClassLoader());
+
+        List<Class<?>> factories = this.contributor.loadSpringFactories(buildContext).stream()
+                .filter(factory -> TestFactory.class.isAssignableFrom(factory.getFactoryType()))
+                .map(SpringFactory::getFactory)
+                .collect(Collectors.toList());
+
+        assertThat(factories).containsExactlyInAnyOrder(PublicFactory.class, OtherFactory.class);
+    }
+
+}

--- a/spring-aot/src/test/resources/META-INF/spring.factories
+++ b/spring-aot/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Testing entries with space after comma
+org.springframework.aot.factories.fixtures.TestFactory= \
+  org.springframework.aot.factories.fixtures.PublicFactory, org.springframework.aot.factories.fixtures.OtherFactory


### PR DESCRIPTION
In `spring.factories`, when there is a space after comma delimiter, it fails to resolve the class and does not create the corresponding `SpringFactory`.

The following `spring.factories` only pick up `FactoryFoo` because there is a space after the comma.

```properties
com.example.MyFactory =\
com.example.FactoryFoo, com.example.FactoryBar
```

```properties
com.example.MyFactory =\
com.example.FactoryFoo, \
com.example.FactoryBar
```

This is because when this entry is loaded and split to an array, it is interpreted as `["com.example.FactoryFoo", " com.example.FactoryBar"]`. The second entry contains a space in front. So that when it creates `SpringFactory` in `SpringFactoriesContributor` it cannot resolve the target class and it is skipped.

In Spring Framework, it applies `trim()` to each entry value.
https://github.com/spring-projects/spring-framework/blob/8dd385b440cb2e432ce7151be08d313982d3b00c/spring-core/src/main/java/org/springframework/core/io/support/SpringFactoriesLoader.java#L153

This PR adds `trim()` while processing the `spring.factories` in `SpringFactoriesContributor`; so that it properly recognizes the entry with spaces.

