### PR TITLE
Sort the factories in "spring.factories"

### DIFF
--- a/spring-aot/src/test/java/org/springframework/aot/factories/SpringFactoriesContributorTests.java
+++ b/spring-aot/src/test/java/org/springframework/aot/factories/SpringFactoriesContributorTests.java
@@ -9,6 +9,10 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.aot.build.context.BuildContext;
+import org.springframework.aot.factories.fixtures.OrderedFactory;
+import org.springframework.aot.factories.fixtures.OrderedFactoryA;
+import org.springframework.aot.factories.fixtures.OrderedFactoryB;
+import org.springframework.aot.factories.fixtures.OrderedFactoryC;
 import org.springframework.aot.factories.fixtures.OtherFactory;
 import org.springframework.aot.factories.fixtures.PublicFactory;
 import org.springframework.aot.factories.fixtures.TestFactory;
@@ -33,6 +37,19 @@ class SpringFactoriesContributorTests {
                 .collect(Collectors.toList());
 
         assertThat(factories).containsExactlyInAnyOrder(PublicFactory.class, OtherFactory.class);
+    }
+
+    @Test
+    void shouldBeSortedByOrder() throws Exception {
+        BuildContext buildContext = mock(BuildContext.class);
+        when(buildContext.getClassLoader()).thenReturn(this.getClass().getClassLoader());
+
+        List<Class<?>> factories = this.contributor.loadSpringFactories(buildContext).stream()
+                .filter(factory -> OrderedFactory.class.isAssignableFrom(factory.getFactoryType()))
+                .map(SpringFactory::getFactory)
+                .collect(Collectors.toList());
+
+        assertThat(factories).containsExactly(OrderedFactoryC.class, OrderedFactoryA.class, OrderedFactoryB.class);
     }
 
 }

--- a/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactory.java
+++ b/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactory.java
@@ -1,0 +1,5 @@
+package org.springframework.aot.factories.fixtures;
+
+public interface OrderedFactory {
+
+}

--- a/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactoryA.java
+++ b/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactoryA.java
@@ -1,0 +1,8 @@
+package org.springframework.aot.factories.fixtures;
+
+import org.springframework.core.annotation.Order;
+
+@Order(20)
+public class OrderedFactoryA implements OrderedFactory {
+
+}

--- a/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactoryB.java
+++ b/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactoryB.java
@@ -1,0 +1,11 @@
+package org.springframework.aot.factories.fixtures;
+
+import org.springframework.core.Ordered;
+
+public class OrderedFactoryB implements OrderedFactory, Ordered {
+
+    @Override
+    public int getOrder() {
+        return 30;
+    }
+}

--- a/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactoryC.java
+++ b/spring-aot/src/test/java/org/springframework/aot/factories/fixtures/OrderedFactoryC.java
@@ -1,0 +1,8 @@
+package org.springframework.aot.factories.fixtures;
+
+import org.springframework.core.annotation.Order;
+
+@Order(10)
+public class OrderedFactoryC implements OrderedFactory {
+
+}

--- a/spring-aot/src/test/resources/META-INF/spring.factories
+++ b/spring-aot/src/test/resources/META-INF/spring.factories
@@ -1,3 +1,8 @@
 # Testing entries with space after comma
 org.springframework.aot.factories.fixtures.TestFactory= \
   org.springframework.aot.factories.fixtures.PublicFactory, org.springframework.aot.factories.fixtures.OtherFactory
+
+org.springframework.aot.factories.fixtures.OrderedFactory=\
+org.springframework.aot.factories.fixtures.OrderedFactoryA,\
+org.springframework.aot.factories.fixtures.OrderedFactoryB,\
+org.springframework.aot.factories.fixtures.OrderedFactoryC


### PR DESCRIPTION
In the Spring Framework, `SpringFactoriesLoader` returns sorted factories(by `@Order` and `Ordered`).

This PR applies the same ordering algorithm to the `SpringFactory` instances; so that, the generated `StaticSpringFactories` holds the proper orderings.