### PR TITLE
make reflection analysis cover kotlin coroutines usage

### DIFF
--- a/samples/webflux-kotlin/src/main/kotlin/com/example/webflux/WebfluxApplication.kt
+++ b/samples/webflux-kotlin/src/main/kotlin/com/example/webflux/WebfluxApplication.kt
@@ -7,8 +7,6 @@ import org.springframework.nativex.hint.NativeHint
 import org.springframework.nativex.hint.TypeAccess
 import org.springframework.nativex.hint.TypeHint
 
-// Reflection entry required due to how Coroutines generates bytecode with an Object return type, see https://github.com/spring-projects/spring-framework/issues/21546 related issue
-@TypeHint(types = [Bar::class], access = [ TypeAccess.DECLARED_CONSTRUCTORS, TypeAccess.DECLARED_METHODS ])
 @SpringBootApplication
 class WebfluxApplication
 

--- a/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeConfigurationUtils.java
+++ b/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeConfigurationUtils.java
@@ -91,7 +91,13 @@ public class NativeConfigurationUtils {
 			// not interesting, although should bound be considered?
 		}
 		else if (type instanceof WildcardType) {
-			// not interesting, although should bound be considered?
+			WildcardType wType = (WildcardType) type;
+			for (Type typeUpper : wType.getUpperBounds()) {
+				collectReferenceTypesUsed(typeUpper, collector);
+			}
+			for (Type typeLower : wType.getLowerBounds()) {
+				collectReferenceTypesUsed(typeLower, collector);
+			}
 		}
 		else if (type instanceof Class) {
 			Class<?> clazz = (Class<?>) type;

--- a/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeConfigurationUtils.java
+++ b/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeConfigurationUtils.java
@@ -23,9 +23,12 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
+
+import org.springframework.core.KotlinDetector;
 
 // TODO review - does spring core already do some of these things?
 
@@ -56,8 +59,19 @@ public class NativeConfigurationUtils {
 	 */
 	public static Set<Class<?>> collectTypesInSignature(Method controllerMethod) {
 		Set<Class<?>> collector = new TreeSet<>(Comparator.comparing(Class::getName));
-		collectReferenceTypesUsed(controllerMethod.getGenericReturnType(), collector);
-		for (Type parameterType : controllerMethod.getGenericParameterTypes()) {
+		Type genericReturnType;
+		Type[] genericParameterTypes;
+		if (KotlinDetector.isSuspendingFunction(controllerMethod)) {
+			Type[] types = controllerMethod.getGenericParameterTypes();
+			ParameterizedType continuation = (ParameterizedType) types[types.length - 1];
+			genericReturnType = ((WildcardType) continuation.getActualTypeArguments()[0]).getLowerBounds()[0];
+			genericParameterTypes = Arrays.copyOf(types, types.length - 1);
+		} else {
+			genericReturnType = controllerMethod.getGenericReturnType();
+			genericParameterTypes = controllerMethod.getGenericParameterTypes();
+		}
+		collectReferenceTypesUsed(genericReturnType, collector);
+		for (Type parameterType : genericParameterTypes) {
 			collectReferenceTypesUsed(parameterType, collector);
 		}
 		return collector;
@@ -91,13 +105,7 @@ public class NativeConfigurationUtils {
 			// not interesting, although should bound be considered?
 		}
 		else if (type instanceof WildcardType) {
-			WildcardType wType = (WildcardType) type;
-			for (Type typeUpper : wType.getUpperBounds()) {
-				collectReferenceTypesUsed(typeUpper, collector);
-			}
-			for (Type typeLower : wType.getLowerBounds()) {
-				collectReferenceTypesUsed(typeLower, collector);
-			}
+			// not interesting, although should bound be considered?
 		}
 		else if (type instanceof Class) {
 			Class<?> clazz = (Class<?>) type;


### PR DESCRIPTION
If a controller method is kotlin coroutine suspend fun, it's return type will be `Continuation<? super Bar>`

In this situation, `returnType.getActualTypeArguments()[0]` will be `? super Bar`, it's a WildcardType, and lower bounds is the exact return type `Bar`.

So we need to dig out the type `Bar` from the original wrapped Continuation type.

If just skip the WildcardType, suspend fun will be considered as a method which return Object.

Adding a lot of @TypeHint is very bad for migrating old projects to spring native, I want to analyze directly in spring aot to get the actual return value of suspend fun.