### PR TITLE
Update proxy hints for usage with EnableJpaRepositories annotation.

### DIFF
--- a/samples/data-jpa/src/main/java/app/main/SampleApplication.java
+++ b/samples/data-jpa/src/main/java/app/main/SampleApplication.java
@@ -24,7 +24,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.web.servlet.function.RouterFunction;
 
 import java.util.Optional;
@@ -35,6 +35,7 @@ import static org.springframework.web.servlet.function.ServerResponse.*;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "fixedAuditor")
+@EnableJpaRepositories(basePackageClasses = FooRepository.class)
 public class SampleApplication {
 
 	private final FooRepository entities;

--- a/spring-native-configuration/src/main/java/org/springframework/data/jpa/repository/config/DataJpaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/data/jpa/repository/config/DataJpaHints.java
@@ -21,6 +21,8 @@ import org.springframework.data.DataAuditingHints;
 import org.springframework.data.DataNonReactiveAuditingHints;
 import org.springframework.data.jpa.domain.support.AuditingBeanFactoryPostProcessor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
+import org.springframework.nativex.hint.JdkProxyHint;
 import org.springframework.nativex.hint.NativeHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
@@ -34,6 +36,18 @@ import org.springframework.nativex.type.NativeConfiguration;
 				AuditingEntityListener.class
 		}),
 		imports = DataNonReactiveAuditingHints.class
+)
+@NativeHint(
+		trigger = JpaRepositoryFactory.class,
+		jdkProxies = {
+				@JdkProxyHint(types = {
+						org.springframework.data.jpa.repository.support.CrudMethodMetadata.class,
+						org.springframework.aop.SpringProxy.class,
+						org.springframework.aop.framework.Advised.class,
+						org.springframework.core.DecoratingProxy.class
+				})
+		}
+
 )
 public class DataJpaHints implements NativeConfiguration {
 


### PR DESCRIPTION
This PR makes sure to add the required jdk proxy configuration when working with the data-jpa specific `@Enable*` annotation.

A more fine grained trigger, that actually checks if the annotation is used in the configuration, would be nice, but this should do for now.

Resolves: #1405 