### PR TITLE
Support "args" param in "@SpringBootTest"

### DIFF
--- a/spring-aot-test/src/main/java/org/springframework/aot/test/boot/SpringBootAotTestContextProcessor.java
+++ b/spring-aot-test/src/main/java/org/springframework/aot/test/boot/SpringBootAotTestContextProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,19 @@
 
 package org.springframework.aot.test.boot;
 
+import java.util.Arrays;
+
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.CodeBlock.Builder;
 
+import org.springframework.aot.context.bootstrap.generator.bean.support.MultiCodeBlock;
 import org.springframework.aot.test.context.bootstrap.generator.AotTestContextProcessor;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.test.context.ReactiveWebMergedContextConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.SpringBootTestArgsAccessor;
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.annotation.MergedAnnotations;
@@ -62,16 +66,22 @@ class SpringBootAotTestContextProcessor implements AotTestContextProcessor {
 
 	@Override
 	public CodeBlock writeInstanceSupplier(MergedContextConfiguration config, ClassName applicationContextInitializer) {
+		String[] args = SpringBootTestArgsAccessor.get(config.getContextCustomizers());
+
 		Builder code = CodeBlock.builder();
 		code.add("() -> new $T($T.class", AotSpringBootConfigContextLoader.class, applicationContextInitializer);
 		WebApplicationType webApplicationType = detectWebApplicationType(config);
-		if (webApplicationType.equals(WebApplicationType.NONE)) {
-			code.add(")");
-		}
-		else {
-			code.add(", $T.$L, $T.$L)", WebApplicationType.class, webApplicationType,
+		if (!webApplicationType.equals(WebApplicationType.NONE)) {
+			code.add(", $T.$L, $T.$L", WebApplicationType.class, webApplicationType,
 					WebEnvironment.class, detectWebEnvironment(config));
 		}
+		if (args.length > 0) {
+			MultiCodeBlock multi = new MultiCodeBlock();
+			Arrays.stream(args).forEach((arg) -> multi.add("$S", arg));
+			code.add(", $L", multi.join(", "));
+		}
+		code.add(")");
+
 		return code.build();
 	}
 

--- a/spring-aot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestArgsAccessor.java
+++ b/spring-aot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestArgsAccessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.context;
+
+import java.util.Set;
+
+import org.springframework.test.context.ContextCustomizer;
+
+/**
+ * Provide access to the package private {@link SpringBootTestArgs} class.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class SpringBootTestArgsAccessor {
+
+	public static String[] get(Set<ContextCustomizer> customizers) {
+		return SpringBootTestArgs.get(customizers);
+	}
+
+	public static ContextCustomizer create(Class<?> testClass) {
+		return new SpringBootTestArgs(testClass);
+	}
+
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/boot/AotSpringBootConfigContextLoader.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/boot/AotSpringBootConfigContextLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,34 +55,36 @@ public class AotSpringBootConfigContextLoader extends SpringBootContextLoader {
 
 	private final WebEnvironment webEnvironment;
 
+	private final String[] args;
+
 	/**
 	 * Create an instance for the specified {@link ApplicationContextInitializer} and
 	 * web-related details.
 	 * @param testContextInitializer the context initializer to use
 	 * @param webApplicationType the {@link WebApplicationType} to use for the context
 	 * @param webEnvironment the {@link WebEnvironment} to use for the context
+	 * @param args the command line arguments
 	 */
 	public AotSpringBootConfigContextLoader(Class<? extends ApplicationContextInitializer<?>> testContextInitializer,
-			WebApplicationType webApplicationType, WebEnvironment webEnvironment) {
+			WebApplicationType webApplicationType, WebEnvironment webEnvironment, String... args) {
 		this.testContextInitializer = testContextInitializer;
 		this.webApplicationType = webApplicationType;
 		this.webEnvironment = webEnvironment;
+		this.args = args;
 	}
 
 	/**
 	 * Create a new instance using the specified {@link ApplicationContextInitializer} for
 	 * a non-web context.
 	 * @param testContextInitializer the context initializer to use
+	 * @param args the command line arguments
 	 */
-	public AotSpringBootConfigContextLoader(Class<? extends ApplicationContextInitializer<?>> testContextInitializer) {
-		this(testContextInitializer, WebApplicationType.NONE, WebEnvironment.NONE);
+	public AotSpringBootConfigContextLoader(Class<? extends ApplicationContextInitializer<?>> testContextInitializer, String... args) {
+		this(testContextInitializer, WebApplicationType.NONE, WebEnvironment.NONE, args);
 	}
 
 	@Override
 	public ConfigurableApplicationContext loadContext(MergedContextConfiguration config) {
-		// TODO: handle application arguments
-		String[] args = new String[0];
-
 		SpringApplication application = new AotTestSpringApplication(config.getTestClass().getClassLoader(), testContextInitializer);
 		application.setMainApplicationClass(config.getTestClass());
 		application.setSources(Collections.singleton(testContextInitializer.getName()));
@@ -108,7 +110,7 @@ public class AotSpringBootConfigContextLoader extends SpringBootContextLoader {
 						ApplicationContextFactory.of(GenericReactiveWebApplicationContext::new));
 			}
 		}
-		ConfigurableApplicationContext context = application.run(args);
+		ConfigurableApplicationContext context = application.run(this.args);
 
 		return context;
 	}


### PR DESCRIPTION
Reflectively access `SpringBootTestArgs`(package private) to support `args` param in `@SpringBootTest`.
