### PR TITLE
"@EnabledOnAot" and "@EnabledOnNative" annotations

### DIFF
--- a/spring-native-docs/src/main/asciidoc/getting-started-native-build-tools.adoc
+++ b/spring-native-docs/src/main/asciidoc/getting-started-native-build-tools.adoc
@@ -369,3 +369,10 @@ $ gradle nativeTest
 ----
 
 You can find more details about the native build tools https://github.com/graalvm/native-build-tools[here].
+
+To conditionally enable/disable tests, we provide the following annotations:
+
+- `@EnabledOnAot`
+- `@DisabledOnAot`
+- `@EnabledOnNative`
+- `@DisabledOnNative`

--- a/spring-native/pom.xml
+++ b/spring-native/pom.xml
@@ -62,6 +62,11 @@
 			<artifactId>spring-boot-test</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>jakarta.validation</groupId>

--- a/spring-native/src/main/java/org/springframework/aot/test/DisabledOnAot.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/DisabledOnAot.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@code @DisabledOnAot} is used to signal that the annotated test class or
+ * test method is <em>disabled</em> if running in AOT mode.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(DisabledOnAotCondition.class)
+public @interface DisabledOnAot {
+
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/DisabledOnAotCondition.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/DisabledOnAotCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.springframework.nativex.AotModeDetector;
+import org.springframework.util.Assert;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ExecutionCondition} for {@link DisabledOnAot @DisabledOnAot}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @author Sam Brannen
+ */
+class DisabledOnAotCondition implements ExecutionCondition {
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Assert.state(context.getElement().isPresent(), "No AnnotatedElement");
+		AnnotatedElement element = context.getElement().get();
+
+		if (isRunningAotTests()) {
+			return ConditionEvaluationResult.disabled(format("%s is disabled on aot mode", element));
+		}
+		else {
+			return ConditionEvaluationResult.enabled(format("%s is enabled on non aot mode", element));
+		}
+	}
+
+	/**
+	 * Determine if we are running AOT tests.
+	 *
+	 * <p>The default implementation delegates to
+	 * {@link AotModeDetector#isRunningAotTests()}. Can be overridden in a subclass for
+	 * testing purposes.
+	 */
+	boolean isRunningAotTests() {
+		return AotModeDetector.isRunningAotTests();
+	}
+
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/DisabledOnNative.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/DisabledOnNative.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@code @DisabledOnNative} is used to signal that the annotated test class or
+ * test method is <em>disabled</em> if running on a native image.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(DisabledOnNativeCondition.class)
+public @interface DisabledOnNative {
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/DisabledOnNativeCondition.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/DisabledOnNativeCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.springframework.core.NativeDetector;
+import org.springframework.util.Assert;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ExecutionCondition} for {@link DisabledOnNative @DisabledOnNative}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @author Sam Brannen
+ */
+class DisabledOnNativeCondition implements ExecutionCondition {
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Assert.state(context.getElement().isPresent(), "No AnnotatedElement");
+		AnnotatedElement element = context.getElement().get();
+
+		if (inNativeImage()) {
+			return ConditionEvaluationResult.disabled(format("%s is disabled on native image", element));
+		}
+		else {
+			return ConditionEvaluationResult.enabled(format("%s is enabled on non native image", element));
+		}
+	}
+
+	/**
+	 * Determine if we are running in a native image.
+	 *
+	 * <p>The default implementation delegates to
+	 * {@link NativeDetector#inNativeImage()}. Can be overridden in a subclass for
+	 * testing purposes.
+	 */
+	boolean inNativeImage() {
+		return NativeDetector.inNativeImage();
+	}
+
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/EnabledOnAot.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/EnabledOnAot.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@code @EnabledOnAot} is used to signal that the annotated test class or
+ * test method is only <em>enabled</em> if running in AOT mode.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(EnabledOnAotCondition.class)
+public @interface EnabledOnAot {
+
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/EnabledOnAotCondition.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/EnabledOnAotCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.springframework.nativex.AotModeDetector;
+import org.springframework.util.Assert;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ExecutionCondition} for {@link EnabledOnAot @EnabledOnAot}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @author Sam Brannen
+ */
+class EnabledOnAotCondition implements ExecutionCondition {
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Assert.state(context.getElement().isPresent(), "No AnnotatedElement");
+		AnnotatedElement element = context.getElement().get();
+
+		if (isRunningAotTests()) {
+			return ConditionEvaluationResult.enabled(format("%s is enabled on aot mode", element));
+		}
+		else {
+			return ConditionEvaluationResult.disabled(format("%s is disabled on non aot mode", element));
+		}
+	}
+
+	/**
+	 * Determine if we are running AOT tests.
+	 *
+	 * <p>The default implementation delegates to
+	 * {@link AotModeDetector#isRunningAotTests()}. Can be overridden in a subclass for
+	 * testing purposes.
+	 */
+	boolean isRunningAotTests() {
+		return AotModeDetector.isRunningAotTests();
+	}
+
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/EnabledOnNative.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/EnabledOnNative.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@code @EnabledOnNative} is used to signal that the annotated test class or
+ * test method is only <em>enabled</em> if running on a native image.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(EnabledOnNativeCondition.class)
+public @interface EnabledOnNative {
+}

--- a/spring-native/src/main/java/org/springframework/aot/test/EnabledOnNativeCondition.java
+++ b/spring-native/src/main/java/org/springframework/aot/test/EnabledOnNativeCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.springframework.core.NativeDetector;
+import org.springframework.util.Assert;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ExecutionCondition} for {@link EnabledOnNative @EnabledOnNative}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @author Sam Brannen
+ */
+class EnabledOnNativeCondition implements ExecutionCondition {
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Assert.state(context.getElement().isPresent(), "No AnnotatedElement");
+		AnnotatedElement element = context.getElement().get();
+
+		if (inNativeImage()) {
+			return ConditionEvaluationResult.enabled(format("%s is enabled on native image", element));
+		}
+		else {
+			return ConditionEvaluationResult.disabled(format("%s is disabled on non native image", element));
+		}
+	}
+
+	/**
+	 * Determine if we are running in a native image.
+	 *
+	 * <p>The default implementation delegates to
+	 * {@link NativeDetector#inNativeImage()}. Can be overridden in a subclass for
+	 * testing purposes.
+	 */
+	boolean inNativeImage() {
+		return NativeDetector.inNativeImage();
+	}
+
+}

--- a/spring-native/src/test/java/org/springframework/aot/test/OnAotConditionTests.java
+++ b/spring-native/src/test/java/org/springframework/aot/test/OnAotConditionTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link EnabledOnAotCondition} and {@link DisabledOnAotCondition}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @author Sam Brannen
+ */
+class OnAotConditionTests {
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@MethodSource({ "aot", "nonAot" })
+	void evaluateCondition(ExecutionCondition condition, boolean isDisabled, String expectedReason) {
+		ExtensionContext context = mock(ExtensionContext.class);
+		when(context.getElement()).thenReturn(Optional.of(mock(AnnotatedElement.class)));
+
+		ConditionEvaluationResult result = condition.evaluateExecutionCondition(context);
+		assertThat(result).isNotNull();
+		assertThat(result.isDisabled()).as("condition is disabled").isEqualTo(isDisabled);
+		assertThat(result.getReason()).get(STRING).matches(expectedReason);
+	}
+
+	static Stream<Arguments> aot() {
+		EnabledOnAotCondition enabledOnAot = new EnabledOnAotCondition() {
+			@Override
+			boolean isRunningAotTests() {
+				return true;
+			}
+		};
+		DisabledOnAotCondition disabledOnAot = new DisabledOnAotCondition() {
+			@Override
+			boolean isRunningAotTests() {
+				return true;
+			}
+		};
+		return Stream.of(
+				arguments(named("@EnabledOnAot condition on AOT mode", enabledOnAot),
+						false, "^.+ is enabled on aot mode$"),
+				arguments(named("@DisabledOnAot condition on AOT mode", disabledOnAot),
+						true, "^.+ is disabled on aot mode$")
+		);
+	}
+
+	static Stream<Arguments> nonAot() {
+		EnabledOnAotCondition enabledOnAot = new EnabledOnAotCondition() {
+			@Override
+			boolean isRunningAotTests() {
+				return false;
+			}
+		};
+		DisabledOnAotCondition disabledOnAot = new DisabledOnAotCondition() {
+			@Override
+			boolean isRunningAotTests() {
+				return false;
+			}
+		};
+		return Stream.of(
+				arguments(named("@EnabledOnAot condition on non-AOT mode", enabledOnAot),
+						true, "^.+ is disabled on non aot mode$"),
+				arguments(named("@DisabledOnAot condition on non-AOT mode", disabledOnAot),
+						false, "^.+ is enabled on non aot mode$")
+		);
+	}
+
+}

--- a/spring-native/src/test/java/org/springframework/aot/test/OnNativeConditionTests.java
+++ b/spring-native/src/test/java/org/springframework/aot/test/OnNativeConditionTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.aot.test;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link EnabledOnNativeCondition} and {@link DisabledOnNativeCondition}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @author Sam Brannen
+ */
+class OnNativeConditionTests {
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@MethodSource({ "onJvm", "onNative" })
+	void evaluateCondition(ExecutionCondition condition, boolean isDisabled, String expectedReason) {
+		ExtensionContext context = mock(ExtensionContext.class);
+		when(context.getElement()).thenReturn(Optional.of(mock(AnnotatedElement.class)));
+
+		ConditionEvaluationResult result = condition.evaluateExecutionCondition(context);
+		assertThat(result).isNotNull();
+		assertThat(result.isDisabled()).as("condition is disabled").isEqualTo(isDisabled);
+		assertThat(result.getReason()).get(STRING).matches(expectedReason);
+	}
+
+	static Stream<Arguments> onJvm() {
+		EnabledOnNativeCondition enabledOnNative = new EnabledOnNativeCondition() {
+			@Override
+			boolean inNativeImage() {
+				return false;
+			}
+		};
+		DisabledOnNativeCondition disabledOnNative = new DisabledOnNativeCondition() {
+			@Override
+			boolean inNativeImage() {
+				return false;
+			}
+		};
+		return Stream.of(
+				arguments(named("@EnabledOnNative condition on JVM", enabledOnNative),
+						true, "^.+ is disabled on non native image$"),
+				arguments(named("@DisabledOnNative condition on JVM", disabledOnNative),
+						false, "^.+ is enabled on non native image$")
+		);
+	}
+
+	static Stream<Arguments> onNative() {
+		EnabledOnNativeCondition enabledOnNative = new EnabledOnNativeCondition() {
+			@Override
+			boolean inNativeImage() {
+				return true;
+			}
+		};
+		DisabledOnNativeCondition disabledOnNative = new DisabledOnNativeCondition() {
+			@Override
+			boolean inNativeImage() {
+				return true;
+			}
+		};
+		return Stream.of(
+				arguments(named("@EnabledOnNative condition on native image", enabledOnNative),
+						false, "^.+ is enabled on native image$"),
+				arguments(named("@DisabledOnNative condition on native image", disabledOnNative),
+						true, "^.+ is disabled on native image$")
+		);
+	}
+
+}


### PR DESCRIPTION
I'm experimenting `@EnabledOnAot`, `@DisabledOnAot`, `@EnabledOnNative`, and `@DisabledOnNative` annotations.

These are directly implementing JUnit5 `ExecutionCondition`.
Another approach would be to meta annotate with `@EnabledIf` with SpEL. But it requires a test to be a spring test. So, instead, I am making them direct Junit5 extensions.
