### PR TITLE
Prepend AOT jar to classpath for bootJar Gradle task

### DIFF
--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
@@ -134,8 +134,10 @@ public class SpringAotGradlePlugin implements Plugin<Project> {
 			// Generated+compiled sources must be used by 'bootRun' and packaged by 'bootJar'
 			project.getPlugins().withType(SpringBootPlugin.class, springBootPlugin -> {
 				Provider<RegularFile> generatedSources = generatedSourcesJar.getArchiveFile();
-				project.getTasks().named(SpringBootPlugin.BOOT_JAR_TASK_NAME, BootJar.class, (bootJar) ->
-						bootJar.classpath(generatedSources));
+				project.getTasks().named(SpringBootPlugin.BOOT_JAR_TASK_NAME, BootJar.class, (bootJar) -> {
+					FileCollection existingClasspath = bootJar.getClasspath();
+					bootJar.setClasspath(bootJar.getProject().files(generatedSources, new Object[]{existingClasspath != null ? existingClasspath : Collections.emptyList()}));
+				});
 				project.getTasks().named("bootRun", BootRun.class, (bootRun) ->
 						bootRun.classpath(generatedSources));
 			});

--- a/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
+++ b/spring-aot-gradle-plugin/src/main/java/org/springframework/aot/gradle/SpringAotGradlePlugin.java
@@ -138,8 +138,10 @@ public class SpringAotGradlePlugin implements Plugin<Project> {
 					FileCollection existingClasspath = bootJar.getClasspath();
 					bootJar.setClasspath(bootJar.getProject().files(generatedSources, new Object[]{existingClasspath != null ? existingClasspath : Collections.emptyList()}));
 				});
-				project.getTasks().named("bootRun", BootRun.class, (bootRun) ->
-						bootRun.classpath(generatedSources));
+				project.getTasks().named("bootRun", BootRun.class, (bootRun) -> {
+					FileCollection existingClasspath = bootRun.getClasspath();
+					bootRun.setClasspath(bootRun.getProject().files(generatedSources, new Object[]{existingClasspath != null ? existingClasspath : Collections.emptyList()}));
+				});
 			});
 
 			// Create a detached configuration that holds dependencies for AOT test generation


### PR DESCRIPTION
Have the spring aot gradle plugin put generated aot jar at the beginning of the boot jar classpath rather than the end. 

Fixes https://github.com/spring-projects-experimental/spring-native/issues/1463