### PR TITLE
spring-aot-test: Include test with multiple Extend or Nested

### DIFF
--- a/spring-aot-test/src/test/java/org/springframework/aot/test/build/TestClassesFinderTests.java
+++ b/spring-aot-test/src/test/java/org/springframework/aot/test/build/TestClassesFinderTests.java
@@ -42,7 +42,9 @@ class TestClassesFinderTests {
 
 	static List<String> TEST_CLASSES = Arrays.asList("ExtendedWithSpring.class", "ExtendedWithTestWatcher.class",
 			"SpringBootTestAnnotated.class", "SimpleClass.class", "MultipleExtendsWithSpring.class",
-			"SpringWithNestedTest.class", "SpringWithNestedTest$NestedTest.class", "SpringWithNestedTest$NestedTest$NestedTest2.class");
+			"SpringWithNestedTest.class", "SpringWithNestedTest$NestedTest.class", "SpringWithNestedTest$NestedTest$NestedTest2.class",
+			"RandomClassWithNested.class", "RandomClassWithNested$NestedTest.class"
+	);
 
 	@TempDir
 	static Path tempDirectory;

--- a/spring-aot-test/src/test/java/org/springframework/aot/test/build/TestClassesFinderTests.java
+++ b/spring-aot-test/src/test/java/org/springframework/aot/test/build/TestClassesFinderTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.aot.test.build;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -23,10 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +41,8 @@ class TestClassesFinderTests {
 	static String PACKAGE = "/org/springframework/aot/test/samples/tests/";
 
 	static List<String> TEST_CLASSES = Arrays.asList("ExtendedWithSpring.class", "ExtendedWithTestWatcher.class",
-			"SpringBootTestAnnotated.class", "SimpleClass.class");
+			"SpringBootTestAnnotated.class", "SimpleClass.class", "MultipleExtendsWithSpring.class",
+			"SpringWithNestedTest.class", "SpringWithNestedTest$NestedTest.class", "SpringWithNestedTest$NestedTest$NestedTest2.class");
 
 	@TempDir
 	static Path tempDirectory;
@@ -62,6 +63,10 @@ class TestClassesFinderTests {
 	void detectTestClasses() throws IOException {
 		List<String> testClasses = TestClassesFinder.findTestClasses(tempDirectory);
 		assertThat(testClasses).containsOnly("org.springframework.aot.test.samples.tests.ExtendedWithSpring",
-				"org.springframework.aot.test.samples.tests.SpringBootTestAnnotated");
+				"org.springframework.aot.test.samples.tests.SpringBootTestAnnotated",
+				"org.springframework.aot.test.samples.tests.MultipleExtendsWithSpring",
+				"org.springframework.aot.test.samples.tests.SpringWithNestedTest",
+				"org.springframework.aot.test.samples.tests.SpringWithNestedTest$NestedTest",
+				"org.springframework.aot.test.samples.tests.SpringWithNestedTest$NestedTest$NestedTest2");
 	}
 }

--- a/spring-aot-test/src/test/java/org/springframework/aot/test/samples/tests/MultipleExtendsWithSpring.java
+++ b/spring-aot-test/src/test/java/org/springframework/aot/test/samples/tests/MultipleExtendsWithSpring.java
@@ -1,0 +1,10 @@
+package org.springframework.aot.test.samples.tests;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
+public class MultipleExtendsWithSpring {
+}

--- a/spring-aot-test/src/test/java/org/springframework/aot/test/samples/tests/RandomClassWithNested.java
+++ b/spring-aot-test/src/test/java/org/springframework/aot/test/samples/tests/RandomClassWithNested.java
@@ -1,0 +1,12 @@
+package org.springframework.aot.test.samples.tests;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+public class RandomClassWithNested {
+    @Nested
+    public class NestedTest {
+    }
+}

--- a/spring-aot-test/src/test/java/org/springframework/aot/test/samples/tests/SpringWithNestedTest.java
+++ b/spring-aot-test/src/test/java/org/springframework/aot/test/samples/tests/SpringWithNestedTest.java
@@ -1,0 +1,15 @@
+package org.springframework.aot.test.samples.tests;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class SpringWithNestedTest {
+    @Nested
+    public class NestedTest {
+        @Nested
+        public class NestedTest2 {
+        }
+    }
+}


### PR DESCRIPTION
This tend to fix  #1427

Sometime, test can have multiple `@ExtendWith`, for instance if you use `TestContainer` or simply use `@ExtendWith(OutputCaptureExtension.class)`.   The current version crash because such test are not picked up correctly.

Also, if you have `@Nested` test, those nested test are not picked up correctly and again, it result in a test failure.

This PR tend to fix that :  Checking every value of `@ExtendWith` annotation  and adding nested class if the enclosing class is a Spring test class.

Signed-off-by: GregoireW <24318548+GregoireW@users.noreply.github.com>