### PR TITLE
Add missing hints to support maintaining order in an element collection

### DIFF
--- a/samples/data-jpa/src/main/java/app/main/model/Foo.java
+++ b/samples/data-jpa/src/main/java/app/main/model/Foo.java
@@ -21,6 +21,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.CascadeType;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.Enumerated;
@@ -28,7 +29,9 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
 import java.time.Instant;
+import java.util.List;
 
 @EntityListeners(AuditingListener.class)
 @Entity
@@ -50,6 +53,10 @@ public class Foo {
 	Instant modifiedAt;
 	@LastModifiedBy
 	String modifiedBy;
+
+	@OrderBy
+	@ElementCollection
+	private List<String> phoneNumbers;
 
 	public Foo() {
 	}

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaHints.java
@@ -84,6 +84,25 @@ import java.util.EventListener;
 						// These three are due to org.hibernate.hql.internal.ast.util.TokenPrinters
 						HqlTokenTypes.class, SqlTokenTypes.class, GeneratedOrderByFragmentRendererTokenTypes.class,
 				}, access = TypeAccess.DECLARED_CONSTRUCTORS),
+				@TypeHint(
+						/*  Required types to support maintaining order in element collection.
+						 *
+						 *	@OrderBy
+						 *	@ElementCollection
+						 *	private List<String> phoneNumbers;
+						 */
+						types = {
+							org.hibernate.sql.ordering.antlr.NodeSupport.class,
+							org.hibernate.sql.ordering.antlr.OrderByFragment.class,
+							org.hibernate.sql.ordering.antlr.SortSpecification.class,
+							org.hibernate.sql.ordering.antlr.SortKey.class,
+							org.hibernate.sql.ordering.antlr.OrderingSpecification.class,
+							org.hibernate.sql.ordering.antlr.CollationSpecification.class
+						},
+						typeNames = {
+							"antlr.CommonAST",
+							"antlr.CommonToken",
+				}),
 				@TypeHint(types = {
 						Id.class, GeneratedValue.class, Repository.class,
 						PersistenceContext.class, MappedSuperclass.class, Column.class, ManyToOne.class, OneToMany.class,


### PR DESCRIPTION
Provide required hints to support maintaining order in element collection jpa/hibernate.

```java
@OrderBy
@ElementCollection
private List<String> phoneNumbers;
```

----

To avoid static hints in future versions we could consider moving the hints into `JpaConfigurationProcessor` only registering them when a trigger annotation is used within the domain model.

Resolves: #1473 
