### PR TITLE
Create CSV files correctly when running under german locale

### DIFF
--- a/build-key-samples.sh
+++ b/build-key-samples.sh
@@ -2,6 +2,9 @@
 
 RC=0
 
+# Uses . as decimal separator
+export LANG=C
+
 echo "GraalVM: `native-image --version`" > samples-summary.csv
 echo "Date,Sample,Build Time (s),Build Mem (GB),RSS Mem (M),Image Size (M),Startup Time (s),JVM Uptime (s), ReflectConfig (lines)" >> samples-summary.csv
 for i in commandlinerunner webflux-netty webmvc-tomcat webflux-thymeleaf grpc jdbc-tx class-proxies-aop batch

--- a/build-samples-aot-only.sh
+++ b/build-samples-aot-only.sh
@@ -2,6 +2,9 @@
 
 RC=0
 
+# Uses . as decimal separator
+export LANG=C
+
 if [ -f samples-summary.csv ]; then
   rm samples-summary.csv
 fi

--- a/build-samples-with-native-tests.sh
+++ b/build-samples-with-native-tests.sh
@@ -2,6 +2,9 @@
 
 RC=0
 
+# Uses . as decimal separator
+export LANG=C
+
 if [ -f samples-summary.csv ]; then
   rm samples-summary.csv
 fi

--- a/build-samples.sh
+++ b/build-samples.sh
@@ -2,6 +2,9 @@
 
 RC=0
 
+# Uses . as decimal separator
+export LANG=C
+
 echo "Testing buildpacks-based builds"
 if ! (cd "samples/commandlinerunner" && mvn -ntp clean package spring-boot:build-image); then
   RC=1


### PR DESCRIPTION
German locale use comma as decimal separator, which breaks the CSV. This change sets the LANG at the start of the scripts to 'C' to ensure that the decimal separator is correct.