### PR TITLE
Spring Aot Maven Plugin does not work with Maven Compiler Plugin > 3.8.1

### DIFF
--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/TestGenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/TestGenerateMojo.java
@@ -38,7 +38,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.twdata.maven.mojoexecutor.MojoExecutor;
 
 import org.springframework.aot.test.build.GenerateTestBootstrapCommand;
 import org.springframework.util.StringUtils;
@@ -151,7 +150,7 @@ public class TestGenerateMojo extends AbstractBootstrapMojo {
 
 			forkJvm(Paths.get(this.project.getBuild().getDirectory()).toFile(), args, Collections.emptyMap());
 
-			compileGeneratedTestSources(sourcesPath, testClasspathElements);
+			compileGeneratedTestSources(sourcesPath);
 			processGeneratedTestResources(resourcesPath, Paths.get(project.getBuild().getTestOutputDirectory()));
 
 			// Write system property as spring.properties file in test resources.
@@ -167,13 +166,11 @@ public class TestGenerateMojo extends AbstractBootstrapMojo {
 		}
 	}
 
-	protected void compileGeneratedTestSources(Path sourcesPath, List<String> testClasspathElements) throws MojoExecutionException {
+	protected void compileGeneratedTestSources(Path sourcesPath) throws MojoExecutionException {
 		String compilerVersion = this.project.getProperties().getProperty("maven-compiler-plugin.version", DEFAULT_COMPILER_PLUGIN_VERSION);
 		project.addTestCompileSourceRoot(sourcesPath.toString());
 		Xpp3Dom compilerConfig = configuration(
-				element("compileSourceRoots", element("compileSourceRoot", sourcesPath.toString())),
-				element("compilePath", testClasspathElements.stream()
-						.map(classpathElement -> element("compilePath", classpathElement)).toArray(MojoExecutor.Element[]::new))
+				element("compileSourceRoots", element("compileSourceRoot", sourcesPath.toString()))
 		);
 		executeMojo(
 				plugin(groupId("org.apache.maven.plugins"), artifactId("maven-compiler-plugin"), version(compilerVersion)),


### PR DESCRIPTION
- Updates the maven-compiler-plugin in the samples to the latest available one, 3.10.1

- The maven-compiler-plugin starting from 3.9.0 removed the configuration option 'compilePath', which the TestGenerateMojo was using. This option was not used and have been removed by the maven-compiler-plugin team in commit https://github.com/apache/maven-compiler-plugin/commit/419bf040893dac8f300deb5b36daf5f487dea8d2

See gh-1514