### PR TITLE
Explicity include ServiceLevelObjectiveBoundary

### DIFF
--- a/spring-native-configuration/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationHints.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics;
+
+import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.TypeHint;
+import org.springframework.nativex.type.NativeConfiguration;
+
+@NativeHint(trigger = MetricsAutoConfiguration.class, types = {
+		@TypeHint(types = {
+				org.springframework.boot.actuate.autoconfigure.metrics.ServiceLevelObjectiveBoundary.class
+		}, access = {})
+})
+public class MetricsAutoConfigurationHints implements NativeConfiguration {
+}

--- a/spring-native-configuration/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsEndpointAutoConfigurationHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsEndpointAutoConfigurationHints.java
@@ -19,8 +19,8 @@ package org.springframework.boot.actuate.autoconfigure.metrics;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.PropertiesConfigAdapter;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimplePropertiesConfigAdapter;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
-import org.springframework.nativex.hint.TypeAccess;
 import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.TypeAccess;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
 
@@ -28,9 +28,7 @@ import org.springframework.nativex.type.NativeConfiguration;
 @NativeHint(trigger = MetricsEndpointAutoConfiguration.class, types = {
 	@TypeHint(types = {
 		PropertiesConfigAdapter.class,
-		SimplePropertiesConfigAdapter.class,
-		org.springframework.boot.actuate.autoconfigure.metrics.ServiceLevelObjectiveBoundary.class,
-		org.springframework.boot.actuate.autoconfigure.metrics.ServiceLevelObjectiveBoundary[].class,
+			SimplePropertiesConfigAdapter.class
 	}),
 	@TypeHint(types = {
 		MetricsEndpoint.class,

--- a/spring-native-configuration/src/main/resources/META-INF/spring.factories
+++ b/spring-native-configuration/src/main/resources/META-INF/spring.factories
@@ -44,6 +44,7 @@ org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfigur
 org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfigurationHints,\
 org.springframework.boot.actuate.autoconfigure.jolokia.JolokiaEndpointAutoConfigurationHints,\
 org.springframework.boot.actuate.autoconfigure.metrics.MetricsEndpointAutoConfigurationHints,\
+org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigurationHints,\
 org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusEndpointAutoConfigurationHints,\
 org.springframework.boot.actuate.autoconfigure.startup.StartupEndpointAutoConfigurationHints,\
 org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfigurationHints,\


### PR DESCRIPTION
This triggers only if MetricsAutoConfiguration is active.

It looks like that this is a GraalVM 22.1 regression. This fix works with both 22.0 and 22.1.

Closes gh-1538