### PR TITLE
Fixes the broken link and outdated plugin name

### DIFF
--- a/spring-native-docs/src/main/asciidoc/native-image-options.adoc
+++ b/spring-native-docs/src/main/asciidoc/native-image-options.adoc
@@ -4,7 +4,7 @@
 GraalVM `native-image` options are documented {graalvm-native-docs}/Options/[here].
 Spring Native is enabling automatically some of those, and some others especially useful are documented here as well.
 
-They can be specified using the `BP_NATIVE_IMAGE_BUILD_ARGUMENTS` environment variable in Spring Boot plugin if you are using {spring-boot-docs}/html/spring-boot-features.html#boot-features-container-images-buildpacks[Buildpacks support] or using the `<buildArgs></buildArgs>` configuration element if you are using `native-image-maven-plugin`.
+They can be specified using the `BP_NATIVE_IMAGE_BUILD_ARGUMENTS` environment variable in Spring Boot plugin if you are using {spring-boot-docs}/html/container-images.html#container-images.buildpacks[Cloud Native Buildpacks] or using the `<buildArgs></buildArgs>` configuration element if you are using `native-maven-plugin`.
 
 [[native-image-options-default]]
 === Options enabled by default


### PR DESCRIPTION
I am using Spring Native 0.11.3 for testing, I get below two small issues:
- Broken link
https://docs.spring.io/spring-boot/docs/2.6.6/reference/html/spring-boot-features.html#boot-features-container-images-buildpacks
-> https://docs.spring.io/spring-boot/docs/2.6.6/reference/html/container-images.html#container-images.buildpacks

- Outdate plugin name
native-image-maven-plugin -> native-maven-plugin