### PR TITLE
Add -l commandline switch to lower native-image priority

### DIFF
--- a/scripts/compileWithGradle.sh
+++ b/scripts/compileWithGradle.sh
@@ -7,6 +7,7 @@ NC='\033[0m'
 
 AOT_ONLY=false
 NATIVE_TESTS=false
+NICENESS=0
 
 while test $# -gt 0; do
   case "$1" in
@@ -26,6 +27,14 @@ while test $# -gt 0; do
       export NATIVE_TESTS=true
       shift
       ;;
+    -l)
+      export NICENESS=19
+      shift
+      ;;
+    --low-priority)
+      export NICENESS=19
+      shift
+      ;;
     *)
       break
       ;;
@@ -40,9 +49,9 @@ mkdir -p build/native
 if [ "$AOT_ONLY" = false ] ; then
   echo "Packaging ${PWD##*/} with Gradle (native)"
   if [ "$NATIVE_TESTS" = false ] ; then
-    ./gradlew nativeCompile &> build/native/output.txt
+    nice -n $NICENESS ./gradlew nativeCompile &> build/native/output.txt
   else
-    ./gradlew nativeTest nativeCompile &> build/native/output.txt
+    nice -n $NICENESS ./gradlew nativeTest nativeCompile &> build/native/output.txt
   fi
 
   if [[ -f build/native/nativeCompile/${PWD##*/} ]]; then
@@ -54,7 +63,7 @@ if [ "$AOT_ONLY" = false ] ; then
   fi
 else
   echo "Packaging ${PWD##*/} with Gradle (AOT only)'"
-  if ./gradlew build &> build/native/output.txt; then
+  if nice -n $NICENESS ./gradlew build &> build/native/output.txt; then
     printf "${GREEN}SUCCESS${NC}\n"
   else
     cat build/native/output.txt

--- a/scripts/compileWithMaven.sh
+++ b/scripts/compileWithMaven.sh
@@ -7,6 +7,7 @@ NC='\033[0m'
 
 AOT_ONLY=false
 NATIVE_TESTS=false
+NICENESS=0
 
 while test $# -gt 0; do
   case "$1" in
@@ -24,6 +25,14 @@ while test $# -gt 0; do
       ;;
     --native-tests)
       export NATIVE_TESTS=true
+      shift
+      ;;
+    -l)
+      export NICENESS=19
+      shift
+      ;;
+    --low-priority)
+      export NICENESS=19
       shift
       ;;
     *)
@@ -44,12 +53,12 @@ mkdir -p target/native
 if [ "$AOT_ONLY" = false ] ; then
   echo "Packaging ${PWD##*/} with Maven (native)"
   if [[ ${PWD##*/} == *-agent ]] ; then
-    mvn test &> target/native/output.txt
+    nice -n $NICENESS mvn test &> target/native/output.txt
   fi
   if [ "$NATIVE_TESTS" = false ] ; then
-    mvn -ntp -DskipTests -Pnative package $* &> target/native/output.txt
+    nice -n $NICENESS mvn -ntp -DskipTests -Pnative package $* &> target/native/output.txt
   else
-    mvn -ntp -Pnative package $* &> target/native/output.txt
+    nice -n $NICENESS mvn -ntp -Pnative package $* &> target/native/output.txt
   fi
 
   if [[ -f target/${PWD##*/} ]]; then
@@ -61,7 +70,7 @@ if [ "$AOT_ONLY" = false ] ; then
   fi
 else
   echo "Packaging ${PWD##*/} with Maven (AOT only)"
-  if mvn -ntp package $* &> target/native/output.txt; then
+  if nice -n $NICENESS mvn -ntp package $* &> target/native/output.txt; then
     printf "${GREEN}SUCCESS${NC}\n"
   else
     cat target/native/output.txt


### PR DESCRIPTION
With this, one can work on the same machine while the sample tests run in the background. This is done by using the `nice` utility from POSIX. The default priority value is `0`, which is used if `-l` (or `--low-priority`) is not used. If `-l` is used, the priority is set to `19`, which is the lowest priority known to POSIX.