### PR TITLE
Fix Spring AOP AspectJ PCD #1580

### DIFF
--- a/samples/class-proxies-aop/src/main/java/com/example/graalvmdemo/aspect/LoggableAspect.java
+++ b/samples/class-proxies-aop/src/main/java/com/example/graalvmdemo/aspect/LoggableAspect.java
@@ -21,7 +21,7 @@ public class LoggableAspect {
 		return joinPoint.proceed();
 	}
 
-	@Pointcut("execution(* com.example.graalvmdemo.rest.PersonController.demo(..))")
+	@Pointcut("execution(* com.example.graalvmdemo.rest.Person*.demo(..))")
 	private void demoMethod() {
 	}
 

--- a/samples/class-proxies-aop/src/main/java/com/example/graalvmdemo/rest/PetController.java
+++ b/samples/class-proxies-aop/src/main/java/com/example/graalvmdemo/rest/PetController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
-public class PersonController2 {
+public class PetController {
 
 	@GetMapping(value="/without")
 	String wemo() {

--- a/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcHints.java
+++ b/spring-native-configuration/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcHints.java
@@ -23,12 +23,17 @@ import org.springframework.nativex.hint.ResourceHint;
 import org.springframework.nativex.hint.TypeHint;
 import org.springframework.nativex.type.NativeConfiguration;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
+import org.springframework.web.filter.RequestContextFilter;
+
+import static org.springframework.nativex.hint.TypeAccess.PUBLIC_METHODS;
+import static org.springframework.nativex.hint.TypeAccess.QUERY_PUBLIC_METHODS;
 
 
 @NativeHint(trigger = WebMvcAutoConfiguration.class,
 	types = {
 		@TypeHint(types = Servlet.class, access = {}),
-		@TypeHint(types = ConfigurableWebApplicationContext.class, access = {})
+		@TypeHint(types = ConfigurableWebApplicationContext.class, access = {}),
+		@TypeHint(types = RequestContextFilter.class, access = {PUBLIC_METHODS, QUERY_PUBLIC_METHODS})
 	},
 	resources = @ResourceHint(patterns="org/springframework/web/util/HtmlCharacterEntityReferences.properties"))
 public class WebMvcHints implements NativeConfiguration {


### PR DESCRIPTION
fix [issues/1580](https://github.com/spring-projects-experimental/spring-native/issues/1580)

Because of RequestContextFilter lose destroy() method, ClassUtils.getMostSpecificMethod return Filter#destroy.