### PR TITLE
Update batch-io sample with FlatFileItemReader

### DIFF
--- a/samples/batch-io/src/main/java/com/example/batch/ItemReaderListener.java
+++ b/samples/batch-io/src/main/java/com/example/batch/ItemReaderListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,51 +16,18 @@
 
 package com.example.batch;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.example.batch.domain.Person;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.batch.item.file.FlatFileItemReader;
 
 /**
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
-public class ItemReaderListener extends AbstractItemCountingItemStreamItemReader<Person>  implements StepExecutionListener {
-
-	private List<Person> people;
-
-	@Override
-	protected Person doRead() throws Exception {
-		if(getCurrentItemCount() < people.size()) {
-			return people.get(getCurrentItemCount());
-		}
-		else {
-			return null;
-		}
-	}
-
-	@Override
-	protected void doOpen() throws Exception {
-		people = new ArrayList<>(8);
-
-		people.add(new Person("Andrew", "Clement"));
-		people.add(new Person("Sebastien", "Deleuze"));
-		people.add(new Person("Jens", "Schauder"));
-		people.add(new Person("Michael", "Minella"));
-		people.add(new Person("David", "Syer"));
-		people.add(new Person("Brian", "Clozel"));
-		people.add(new Person("Andy", "Wilkinson"));
-		people.add(new Person("Eleftheria", "Stein"));
-	}
-
-	@Override
-	protected void doClose() throws Exception {
-
-	}
+public class ItemReaderListener extends FlatFileItemReader<Person> implements StepExecutionListener {
 
 	@Override
 	public void beforeStep(StepExecution stepExecution) {

--- a/samples/batch-io/src/main/java/com/example/batch/configuration/BatchConfiguration.java
+++ b/samples/batch-io/src/main/java/com/example/batch/configuration/BatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,18 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.database.JdbcBatchItemWriter;
 import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper;
+import org.springframework.batch.item.file.mapping.DefaultLineMapper;
+import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 @Configuration(proxyBeanMethods = false)
 public class BatchConfiguration {
@@ -68,6 +73,15 @@ public class BatchConfiguration {
 	public ItemReaderListener reader() {
 		ItemReaderListener itemReaderListener = new ItemReaderListener();
 		itemReaderListener.setName("reader");
+		itemReaderListener.setResource(new ClassPathResource("person.csv"));
+		itemReaderListener.setLineMapper(new DefaultLineMapper<>() {{
+			setLineTokenizer(new DelimitedLineTokenizer() {{
+				setNames("firstName", "lastName");
+			}});
+			setFieldSetMapper(new BeanWrapperFieldSetMapper<>() {{
+				setTargetType(Person.class);
+			}});
+		}});
 		return itemReaderListener;
 	}
 


### PR DESCRIPTION
This commit updates the `batch-io` sample to make the item reader reads data from a flat file (disk IO), as the sample name implies.

However, with this change, the sample fails with the same issue reported in #459 . Any idea why the sample works when the reader extends `AbstractItemCountingItemStreamItemReader` but not when it extends `FlatFileItemReader`?