### PR TITLE
Support lambda class serialization via hints

### DIFF
--- a/spring-aot/src/json-shade/java/org/springframework/nativex/json/JSONArray.java
+++ b/spring-aot/src/json-shade/java/org/springframework/nativex/json/JSONArray.java
@@ -44,7 +44,7 @@ import java.util.List;
  * overridable methods is not specified. See <i>Effective Java</i> Item 17, "Design and
  * Document or inheritance or else prohibit it" for further information.
  */
-public class JSONArray {
+public class JSONArray implements JSONValue {
 
 	private final List<Object> values;
 

--- a/spring-aot/src/json-shade/java/org/springframework/nativex/json/JSONObject.java
+++ b/spring-aot/src/json-shade/java/org/springframework/nativex/json/JSONObject.java
@@ -72,7 +72,7 @@ import java.util.Map;
  * overrideable methods is not specified. See <i>Effective Java</i> Item 17, "Design and
  * Document or inheritance or else prohibit it" for further information.
  */
-public class JSONObject {
+public class JSONObject implements JSONValue {
 
 	private static final Double NEGATIVE_ZERO = -0d;
 

--- a/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeSerializationEntry.java
+++ b/spring-aot/src/main/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeSerializationEntry.java
@@ -27,9 +27,15 @@ import org.springframework.util.ClassUtils;
 public class NativeSerializationEntry {
 
 	private final Class<?> type;
+	private final boolean lambdaCapturing;
 
 	private NativeSerializationEntry(Class<?> type) {
+		this(type, false);
+	}
+
+	private NativeSerializationEntry(Class<?> type, boolean lambdaCapturing) {
 		this.type = type;
+		this.lambdaCapturing = lambdaCapturing;
 	}
 
 	/**
@@ -43,6 +49,16 @@ public class NativeSerializationEntry {
 	}
 
 	/**
+	 * Create a new {@link NativeSerializationEntry} for the lambda capturing types.
+	 * @param type the lambda capturing type
+	 * @return the serialization entry
+	 */
+	public static NativeSerializationEntry ofLambdaCapturingType(Class<?> type) {
+		Assert.notNull(type, "type must not be null");
+		return new NativeSerializationEntry(type, true);
+	}
+
+	/**
 	 * Create a new {@link NativeSerializationEntry} for the specified types.
 	 * @param typeName the related type name
 	 * @return the serialization entry
@@ -52,7 +68,17 @@ public class NativeSerializationEntry {
 		return new NativeSerializationEntry(ClassUtils.resolveClassName(typeName, null));
 	}
 
+	/**
+	 * Create a new {@link NativeSerializationEntry} for the lambda capturing types.
+	 * @param typeName the lambda capturing type name
+	 * @return the serialization entry
+	 */
+	public static NativeSerializationEntry ofLambdaCapturingTypeName(String typeName) {
+		Assert.notNull(typeName, "typeName must not be null");
+		return new NativeSerializationEntry(ClassUtils.resolveClassName(typeName, null), true);
+	}
+
 	public void contribute(SerializationDescriptor descriptor) {
-		descriptor.add(this.type.getName());
+		descriptor.add(this.type.getName(), lambdaCapturing);
 	}
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/serialization/SerializationDescriptor.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/serialization/SerializationDescriptor.java
@@ -26,21 +26,36 @@ import java.util.function.Consumer;
 public class SerializationDescriptor {
 
 	private final Set<String> serializableTypes;
+	private final Set<String> serializableLambdaCapturingTypes;
 
 	public SerializationDescriptor() {
 		this.serializableTypes = new HashSet<>();
+		this.serializableLambdaCapturingTypes = new HashSet<>();
 	}
 
 	public SerializationDescriptor(SerializationDescriptor metadata) {
 		this.serializableTypes = new HashSet<>(metadata.serializableTypes);
+		this.serializableLambdaCapturingTypes = new HashSet<>(metadata.serializableLambdaCapturingTypes);
 	}
 
 	public Set<String> getSerializableTypes() {
 		return this.serializableTypes;
 	}
 
+	public Set<String> getSerializableLambdaCapturingTypes() {
+		return this.serializableLambdaCapturingTypes;
+	}
+
 	public void add(String className) {
 		this.serializableTypes.add(className);
+	}
+
+	public void add(String className, boolean lambdaCapturing) {
+		if (lambdaCapturing) {
+			this.serializableLambdaCapturingTypes.add(className);
+		} else {
+			this.serializableTypes.add(className);
+		}
 	}
 
 	@Override
@@ -64,12 +79,21 @@ public class SerializationDescriptor {
 		serializableTypes.stream().forEach(t -> consumer.accept(t));
 	}
 
+	public void consumeLambdaCapturing(Consumer<String> consumer) {
+		serializableLambdaCapturingTypes.forEach(consumer);
+	}
+
 	public void merge(SerializationDescriptor otherSerializationDescriptor) {
 		serializableTypes.addAll(otherSerializationDescriptor.serializableTypes);
+		serializableLambdaCapturingTypes.addAll(otherSerializationDescriptor.serializableLambdaCapturingTypes);
 	}
 	
 	public boolean contains(String className) {
 		return serializableTypes.contains(className);
+	}
+
+	public boolean containsLambdaCapturing(String className) {
+		return serializableLambdaCapturingTypes.contains(className);
 	}
 
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/domain/serialization/SerializationDescriptorJsonConverter.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/domain/serialization/SerializationDescriptorJsonConverter.java
@@ -18,6 +18,7 @@ package org.springframework.nativex.domain.serialization;
 
 import org.springframework.nativex.json.JSONArray;
 import org.springframework.nativex.json.JSONObject;
+import org.springframework.nativex.json.JSONValue;
 
 /**
  * Converter to change {@link SerializationDescriptor} objects into JSON objects
@@ -26,14 +27,32 @@ import org.springframework.nativex.json.JSONObject;
  */
 class SerializationDescriptorJsonConverter {
 
-	public JSONArray toJsonArray(SerializationDescriptor sd) throws Exception {
-		JSONArray jsonArray = new JSONArray();
+	public JSONValue toJsonValue(SerializationDescriptor sd) throws Exception {
+		if (sd.getSerializableLambdaCapturingTypes().isEmpty()) {
+			JSONArray jsonArray = new JSONArray();
+			for (String type: sd.getSerializableTypes()) {
+				JSONObject jo = new JSONObject();
+				jo.put("name", type);
+				jsonArray.put(jo);
+			}
+			return jsonArray;
+		}
+		JSONObject jsonObject = new JSONObject();
+		JSONArray types = new JSONArray();
 		for (String type: sd.getSerializableTypes()) {
 			JSONObject jo = new JSONObject();
 			jo.put("name", type);
-			jsonArray.put(jo);
+			types.put(jo);
 		}
-		return jsonArray;
+		jsonObject.put("types", types);
+		JSONArray lambdaCapturingTypes = new JSONArray();
+		for (String type: sd.getSerializableLambdaCapturingTypes()) {
+			JSONObject jo = new JSONObject();
+			jo.put("name", type);
+			lambdaCapturingTypes.put(jo);
+		}
+		jsonObject.put("lambdaCapturingTypes", lambdaCapturingTypes);
+		return jsonObject;
 	}
 
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/support/ConfigurationCollector.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/ConfigurationCollector.java
@@ -272,6 +272,17 @@ public class ConfigurationCollector {
 		serializationDescriptor.add(className);
 		return true;
 	}
+
+	public boolean addSerializationLambdaCapturingType(String className, boolean verify) {
+		if (verify) {
+			Type clazz = ts.resolveDotted(className, true);
+			if (clazz == null) {
+				return false;
+			}
+		}
+		serializationDescriptor.add(className, true);
+		return true;
+	}
 	
 	private boolean areMembersSpecified(ClassDescriptor cd) {
 		List<MethodDescriptor> methods = cd.getMethods();

--- a/spring-aot/src/main/java/org/springframework/nativex/support/ResourcesHandler.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/ResourcesHandler.java
@@ -151,6 +151,14 @@ public class ResourcesHandler extends Handler {
 						serializationHandler.addType(st);
 					}
 				}
+
+				Set<String> serializationLambdaCapturingTypes = ch.getSerializationLambdaCapturingTypes();
+				if (!serializationLambdaCapturingTypes.isEmpty()) {
+					logger.debug("Registering lambda capturing types as serializable: "+serializationLambdaCapturingTypes);
+					for (String st: serializationLambdaCapturingTypes) {
+						serializationHandler.addLambdaCapturingType(st);
+					}
+				}
 				List<org.springframework.nativex.type.ResourcesDescriptor> resourcesDescriptors = ch
 						.getResourcesDescriptors();
 				for (org.springframework.nativex.type.ResourcesDescriptor rd : resourcesDescriptors) {

--- a/spring-aot/src/main/java/org/springframework/nativex/support/SerializationHandler.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/support/SerializationHandler.java
@@ -29,5 +29,9 @@ public class SerializationHandler extends Handler {
 	public void addType(String className) {
 		collector.addSerializationType(className, true);
 	}
+
+	public void addLambdaCapturingType(String className) {
+		collector.addSerializationLambdaCapturingType(className, true);
+	}
 	
 }

--- a/spring-aot/src/main/java/org/springframework/nativex/type/HintDeclaration.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/HintDeclaration.java
@@ -43,6 +43,8 @@ public class HintDeclaration {
 	private Map<String, AccessDescriptor> jniTypes = new LinkedHashMap<>();
 
 	private Set<String> serializationTypes = new HashSet<>();
+
+	private Set<String> serializationLambdaCapturingTypes = new HashSet<>();
 	
 	private List<JdkProxyDescriptor> proxyDescriptor = new ArrayList<>();
 
@@ -109,11 +111,19 @@ public class HintDeclaration {
 	public void addSerializationType(String className) {
 		serializationTypes.add(className);
 	}
+
+	public void addSerializationLambdaCapturingType(String className) {
+		serializationLambdaCapturingTypes.add(className);
+	}
 	
 	public Set<String> getSerializationTypes() {
 		return serializationTypes;
 	}
-	
+
+	public Set<String> getSerializationLambdaCapturingTypes() {
+		return serializationLambdaCapturingTypes;
+	}
+
 	public void addDependantType(String className, AccessDescriptor accessDescriptor) {
 		specificTypes.put(className, accessDescriptor);
 	}

--- a/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
+++ b/spring-aot/src/main/java/org/springframework/nativex/type/Type.java
@@ -1715,6 +1715,8 @@ public class Type {
 		List<Object> values = typeInfo.values;
 		List<org.objectweb.asm.Type> types = new ArrayList<>();
 		List<String> typeNames = new ArrayList<>();
+		List<org.objectweb.asm.Type> lambdaCapturingTypes = new ArrayList<>();
+		List<String> lambdaCapturingTypeNames = new ArrayList<>();
 		for (int i = 0; i < values.size(); i += 2) {
 			String key = (String) values.get(i);
 			Object value = values.get(i + 1);
@@ -1722,6 +1724,10 @@ public class Type {
 				types = (ArrayList<org.objectweb.asm.Type>) value;
 			} else if (key.equals("typeNames")) {
 				typeNames = (ArrayList<String>) value;
+			} else if (key.equals("lambdaCapturingTypes")) {
+				lambdaCapturingTypes = (List<org.objectweb.asm.Type>) value;
+			} else if (key.equals("lambdaCapturingTypeNames")) {
+				lambdaCapturingTypeNames = (List<String>) value;
 			}
 		}
 		for (org.objectweb.asm.Type type : types) {
@@ -1731,6 +1737,15 @@ public class Type {
 			Type resolvedType = typeSystem.resolveName(typeName, true);
 			if (resolvedType != null) {
 				ch.addSerializationType(typeName);
+			}
+		}
+		for (org.objectweb.asm.Type type : lambdaCapturingTypes) {
+			ch.addSerializationLambdaCapturingType(type.getClassName());
+		}
+		for (String typeName : lambdaCapturingTypeNames) {
+			Type resolvedType = typeSystem.resolveName(typeName, true);
+			if (resolvedType != null) {
+				ch.addSerializationLambdaCapturingType(typeName);
 			}
 		}
 	}

--- a/spring-aot/src/test/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeConfigurationRegistryTests.java
+++ b/spring-aot/src/test/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeConfigurationRegistryTests.java
@@ -212,11 +212,22 @@ class NativeConfigurationRegistryTests {
 	}
 
 	@Test
+	void addLambdaCapturingSerialization() {
+		registry.serialization().add(NativeSerializationEntry.ofLambdaCapturingType(String.class));
+		assertThat(registry.serialization().toSerializationDescriptor()).satisfies((serializationDescriptor) ->
+				assertThat(serializationDescriptor.getSerializableLambdaCapturingTypes()).singleElement().isEqualTo(String.class.getName()));
+	}
+
+	@Test
 	void addSeveralSerializations() {
 		registry.serialization().add(NativeSerializationEntry.ofType(String.class));
 		registry.serialization().add(NativeSerializationEntry.ofType(Long.class));
+		registry.serialization().add(NativeSerializationEntry.ofLambdaCapturingType(String.class));
+		registry.serialization().add(NativeSerializationEntry.ofLambdaCapturingType(Long.class));
 		assertThat(registry.serialization().toSerializationDescriptor()).satisfies((serializationDescriptor) ->
 				assertThat(serializationDescriptor.getSerializableTypes()).containsOnly(String.class.getName(), Long.class.getName()));
+		assertThat(registry.serialization().toSerializationDescriptor()).satisfies((serializationDescriptor) ->
+				assertThat(serializationDescriptor.getSerializableLambdaCapturingTypes()).containsOnly(String.class.getName(), Long.class.getName()));
 	}
 
 	@Test

--- a/spring-aot/src/test/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeSerializationEntryTests.java
+++ b/spring-aot/src/test/java/org/springframework/aot/context/bootstrap/generator/infrastructure/nativex/NativeSerializationEntryTests.java
@@ -32,24 +32,30 @@ public class NativeSerializationEntryTests {
 	@Test
 	void ofTypeWithNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> NativeSerializationEntry.ofType(null));
+		assertThatIllegalArgumentException().isThrownBy(() -> NativeSerializationEntry.ofLambdaCapturingType(null));
 	}
 
 	@Test
 	void contributeType() {
 		SerializationDescriptor serializationDescriptor = new SerializationDescriptor();
 		NativeSerializationEntry.ofType(String.class).contribute(serializationDescriptor);
+		NativeSerializationEntry.ofLambdaCapturingType(String.class).contribute(serializationDescriptor);
 		assertThat(serializationDescriptor.getSerializableTypes()).singleElement().isEqualTo(String.class.getName());
+		assertThat(serializationDescriptor.getSerializableLambdaCapturingTypes()).singleElement().isEqualTo(String.class.getName());
 	}
 
 	@Test
 	void ofTypeNameWithNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> NativeSerializationEntry.ofTypeName(null));
+		assertThatIllegalArgumentException().isThrownBy(() -> NativeSerializationEntry.ofLambdaCapturingTypeName(null));
 	}
 
 	@Test
 	void contributeTypeName() {
 		SerializationDescriptor serializationDescriptor = new SerializationDescriptor();
 		NativeSerializationEntry.ofTypeName(String.class.getName()).contribute(serializationDescriptor);
+		NativeSerializationEntry.ofLambdaCapturingTypeName(String.class.getName()).contribute(serializationDescriptor);
 		assertThat(serializationDescriptor.getSerializableTypes()).singleElement().isEqualTo(String.class.getName());
+		assertThat(serializationDescriptor.getSerializableLambdaCapturingTypes()).singleElement().isEqualTo(String.class.getName());
 	}
 }

--- a/spring-native/src/main/java/org/springframework/nativex/hint/SerializationHint.java
+++ b/spring-native/src/main/java/org/springframework/nativex/hint/SerializationHint.java
@@ -47,4 +47,16 @@ public @interface SerializationHint {
 	 */
 	String[] typeNames() default {};
 
+	/**
+	 * configure lambdaCapturingTypes for Lambda functions serialization
+	 * @return the lambda capturing types
+	 */
+	Class<?>[] lambdaCapturingTypes() default {};
+
+	/**
+	 * Alternative way to configure lambdaCapturingTypes for Lambda functions serialization
+	 * @return the lambda capturing type names
+	 */
+	String[] lambdaCapturingTypeNames() default {};
+
 }


### PR DESCRIPTION
Currently lambdas serialization https://github.com/oracle/graal/commit/b455f23b624a1af149c7d5769443a4775bedd087 is supported in GraalVM native-image. This commit add lambdaCapturingTypes and lambdaCapturingTypeNames to conveniently add capturing classes to serialization configuration.

Example:

```
public class LambdaClassSerialization {
    private static void serialize(ByteArrayOutputStream byteArrayOutputStream, Serializable serializableObject) throws IOException {
        ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
        objectOutputStream.writeObject(serializableObject);
        objectOutputStream.close();
    }

    private static Object deserialize(ByteArrayOutputStream byteArrayOutputStream) throws IOException, ClassNotFoundException {
        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
        ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
        return objectInputStream.readObject();
    }

    public static void testLambdaClassSerialization() throws Exception {
        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
        Function<Integer, String> function = (Function<Integer, String> & Serializable) (x) -> "Hello";

        serialize(byteArrayOutputStream, (Serializable) function);
        (Function<Integer, String>) deserialize(byteArrayOutputStream);
    }
}

// serialization-config.json output :
// 
// {
//   "types":[
//   ],
//   "lambdaCapturingTypes":[
//     {
//       "name":"com.xxx.LambdaClassSerialization"
//     }
//   ]
// }
@SerializationHint(lambdaCapturingTypes = {LambdaClassSerialization.class})
@SpringBootApplication
public class LambdaClassSerializationSpringApplication {

	public static void main(String[] args) throws Exception {
		SpringApplication.run(LambdaClassSerializationSpringApplication.class, args);
	}

}
```