### PR TITLE
Add cloud-stream-kafka back into samples

### DIFF
--- a/samples/cloud-stream-kafka/build.sh
+++ b/samples/cloud-stream-kafka/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose up -d
+
+${PWD%/*samples/*}/scripts/install3rdPartyHints.sh && ${PWD%/*samples/*}/scripts/compileWithMaven.sh $* &&  ${PWD%/*samples/*}/scripts/test.sh $*
+
+docker-compose down

--- a/samples/cloud-stream-kafka/docker-compose.yml
+++ b/samples/cloud-stream-kafka/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+    kafka:
+      image: wurstmeister/kafka
+      ports:
+        - "9092:9092"
+      environment:
+        - KAFKA_ADVERTISED_HOST_NAME=127.0.0.1
+        - KAFKA_ADVERTISED_PORT=9092
+        - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      depends_on:
+        - zookeeper
+    zookeeper:
+      image: wurstmeister/zookeeper
+      ports:
+        - "2181:2181"
+      environment:
+        - KAFKA_ADVERTISED_HOST_NAME=zookeeper

--- a/samples/cloud-stream-kafka/pom.xml
+++ b/samples/cloud-stream-kafka/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.experimental</groupId>
+		<artifactId>spring-native-sample-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../maven-parent/pom.xml</relativePath>
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>cloud-stream-kafka</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>cloud-stream-kafka</name>
+	<description>Demo project for SCSt Kafka</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-function-context</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-function-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/samples/cloud-stream-kafka/src/main/java/com/example/demo/SpringCloudStreamKafkaApplication.java
+++ b/samples/cloud-stream-kafka/src/main/java/com/example/demo/SpringCloudStreamKafkaApplication.java
@@ -1,0 +1,47 @@
+package com.example.demo;
+
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SpringCloudStreamKafkaApplication {
+
+	@Autowired
+	private StreamBridge streamBridge;
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringCloudStreamKafkaApplication.class, args);
+	}
+
+	@Bean
+	public Function<String, String> graalUppercaseFunction() {
+		return String::toUpperCase;
+	}
+
+	@Bean
+	public Consumer<String> graalLoggingConsumer() {
+		return s -> {
+			System.out.println("++++++Received:" + s);
+			// Verifying that StreamBridge API works in native applications.
+			streamBridge.send("sb-out", s);
+		};
+	}
+
+	@Bean
+	public Supplier<String> graalSupplier() {
+		return () -> {
+			String woodchuck = "How much wood could a woodchuck chuck if a woodchuck could chuck wood?";
+			final String[] splitWoodchuck = woodchuck.split(" ");
+			Random random = new Random();
+			return splitWoodchuck[random.nextInt(splitWoodchuck.length)];
+		};
+	}
+}

--- a/samples/cloud-stream-kafka/src/main/resources/application.yml
+++ b/samples/cloud-stream-kafka/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring.kafka.consumer.auto-offset-reset: earliest
+
+spring.cloud:
+  function:
+    definition: graalSupplier;graalUppercaseFunction;graalLoggingConsumer
+  stream:
+    bindings:
+      graalSupplier-out-0:
+        destination: graalUppercaseFunction-in-0
+      graalLoggingConsumer-in-0:
+        destination: graalUppercaseFunction-out-0

--- a/samples/cloud-stream-kafka/verify.sh
+++ b/samples/cloud-stream-kafka/verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source ${PWD%/*samples/*}/scripts/wait.sh
+wait_log target/native/test-output.txt "Received:(HOW|MUCH|WOOD|COULD|A|WOODCHUCK|CHUCK|IF|COULD|WOOD?)"

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -7,7 +7,7 @@ wait_log() {
 
   for ((i=0; i<=timeout; i++)); do
     if test -f "$file"; then
-      cat "$file" | grep -q "$search_term" && return 0
+      cat "$file" | grep -Eq "$search_term" && return 0
     fi
     sleep 1
   done


### PR DESCRIPTION
When combined w/ the changes in https://github.com/spring-cloud/spring-cloud-stream/pull/2456 `./build.sh --aot-only` passes. 

Next steps are to work on the native image build/run.

@mhalbritter are you ok if we add this back here in spring-native repo and then once it is all working, then I can move it into smoke tests repo?


#### Steps to test-drive
- get the bits from the above PR locally
- `cd spring-cloud-stream/core && ../mvnw clean install -DskipTests`
- get the bits from this PR locally
- `cd spring-native/samples/cloud-stream-kafka && ./build.sh --aot-only`

cc: @OlgaMaciaszek 