### PR TITLE
maybe we could add primary-classes option for spring-aot generation

### DIFF
--- a/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
+++ b/spring-aot-maven-plugin/src/main/java/org/springframework/aot/maven/GenerateMojo.java
@@ -67,6 +67,9 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 	@Parameter(property = "spring.aot.applicationClass")
 	protected String applicationClass;
 
+	@Parameter(property = "spring.aot.primaryClasses")
+	protected List<String> primaryClasses;
+
 	/**
 	 * Location of generated source files created by Spring AOT to bootstrap the application.
 	 */
@@ -127,6 +130,9 @@ public class GenerateMojo extends AbstractBootstrapMojo {
 			}
 			if (this.applicationClass != null) {
 				args.add("--application-class=" + this.applicationClass);
+			}
+			if (this.primaryClasses != null && !this.primaryClasses.isEmpty()) {
+				args.add("--primary-classes=" + String.join(",", this.primaryClasses));
 			}
 
 			forkJvm(Paths.get(this.project.getBuild().getDirectory()).toFile(), args, Collections.emptyMap());

--- a/spring-aot-test/src/main/java/org/springframework/aot/test/build/GenerateTestBootstrapCommand.java
+++ b/spring-aot-test/src/main/java/org/springframework/aot/test/build/GenerateTestBootstrapCommand.java
@@ -57,6 +57,9 @@ public class GenerateTestBootstrapCommand implements Callable<Integer> {
 	@Option(names = {"--resources"}, required = true, split = "${sys:path.separator}", description = "Paths to the application compiled resources.")
 	private Set<Path> resourcesPaths;
 
+	@Option(names = {"--primary-classes"}, split = ",", description = "spring primary classes")
+	private Set<String> primaryClasses;
+
 	@Option(names = "--mode", required = true, description = "The mode which could be native or native-agent")
 	private String mode;
 	
@@ -107,7 +110,7 @@ public class GenerateTestBootstrapCommand implements Callable<Integer> {
 		BootstrapCodeGenerator generator = new BootstrapCodeGenerator(aotOptions, bootstrapContributors);
 		String[] classPath = StringUtils.tokenizeToStringArray(System.getProperty("java.class.path"), File.pathSeparator);
 		ApplicationStructure applicationStructure = new ApplicationStructure(this.sourceOutputPath, this.resourcesOutputPath, this.resourcesPaths,
-				Arrays.asList(this.testClassesFolders), null, null, testClassesNames, Arrays.asList(classPath), classLoader);
+				Arrays.asList(this.testClassesFolders), null, null, testClassesNames, Arrays.asList(classPath), classLoader, new ArrayList<>(primaryClasses));
 		generator.generate(AotPhase.TEST, applicationStructure);
 		return 0;
 	}

--- a/spring-aot/src/main/java/org/springframework/aot/build/ApplicationStructure.java
+++ b/spring-aot/src/main/java/org/springframework/aot/build/ApplicationStructure.java
@@ -53,13 +53,15 @@ public class ApplicationStructure {
 
 	private final String applicationClass;
 
+	private final List<String> primaryClasses;
+
 	private final List<String> testClasses;
 
 	private final ClassLoader classLoader;
 
 	public ApplicationStructure(Path sourcesPath, Path resourcesPath, Set<Path> resourceFolders, List<Path> classesPaths,
 			@Nullable String mainClass, @Nullable String applicationClass, List<String> testClasses, List<String> classpath,
-			@Nullable ClassLoader classLoader) throws IOException {
+			@Nullable ClassLoader classLoader, @Nullable List<String> primaryClasses) throws IOException {
 		this.sourcesPath = sourcesPath;
 		this.resourcesPath = resourcesPath;
 		this.resourceFolders = resourceFolders;
@@ -72,6 +74,7 @@ public class ApplicationStructure {
 			String detectedApplicationClass = detectApplicationClass(classesPaths);
 			this.applicationClass = detectedApplicationClass != null ? detectedApplicationClass : mainClass;
 		}
+		this.primaryClasses = primaryClasses;
 		this.testClasses = testClasses;
 		this.classpath = classpath;
 		this.classLoader = classLoader;
@@ -99,6 +102,10 @@ public class ApplicationStructure {
 
 	public String getApplicationClass() {
 		return applicationClass;
+	}
+
+	public List<String> getPrimaryClasses() {
+		return primaryClasses;
 	}
 
 	public List<String> getTestClasses() {

--- a/spring-aot/src/main/java/org/springframework/aot/build/DefaultBuildContext.java
+++ b/spring-aot/src/main/java/org/springframework/aot/build/DefaultBuildContext.java
@@ -43,6 +43,8 @@ class DefaultBuildContext implements BuildContext {
 
 	private final String applicationClass;
 
+	private final List<String> primaryClasses;
+
 	private final List<String> testClasses;
 
 	private final List<String> classpath;
@@ -68,6 +70,7 @@ class DefaultBuildContext implements BuildContext {
 	DefaultBuildContext(ApplicationStructure applicationStructure) {
 		this.mainClass = applicationStructure.getMainClass();
 		this.applicationClass = applicationStructure.getApplicationClass();
+		this.primaryClasses = applicationStructure.getPrimaryClasses();
 		this.testClasses = applicationStructure.getTestClasses();
 		this.classpath = applicationStructure.getClasspath();
 		this.classLoader = applicationStructure.getClassLoader();
@@ -96,6 +99,11 @@ class DefaultBuildContext implements BuildContext {
 	@Override
 	public String getApplicationClass() {
 		return this.applicationClass;
+	}
+
+	@Override
+	public List<String> getPrimaryClasses() {
+		return primaryClasses;
 	}
 
 	@Override

--- a/spring-aot/src/main/java/org/springframework/aot/build/GenerateBootstrapCommand.java
+++ b/spring-aot/src/main/java/org/springframework/aot/build/GenerateBootstrapCommand.java
@@ -103,7 +103,7 @@ public class GenerateBootstrapCommand implements Callable<Integer> {
 		BootstrapCodeGenerator generator = new BootstrapCodeGenerator(aotOptions, bootstrapContributors);
 		String[] classPath = StringUtils.tokenizeToStringArray(System.getProperty("java.class.path"), File.pathSeparator);
 		ApplicationStructure applicationStructure = new ApplicationStructure(this.sourceOutputPath, this.resourcesOutputPath, this.resourcesPaths,
-				this.classesPaths, this.mainClass, this.applicationClass, Collections.emptyList(), Arrays.asList(classPath), classLoader);
+				this.classesPaths, this.mainClass, this.applicationClass, Collections.emptyList(), Arrays.asList(classPath), classLoader, Collections.emptyList());
 		generator.generate(AotPhase.MAIN, applicationStructure);
 		return 0;
 	}

--- a/spring-aot/src/main/java/org/springframework/aot/build/context/BuildContext.java
+++ b/spring-aot/src/main/java/org/springframework/aot/build/context/BuildContext.java
@@ -54,6 +54,8 @@ public interface BuildContext {
 	 */
 	String getApplicationClass();
 
+	List<String> getPrimaryClasses();
+
 	List<String> getTestClasses();
 
 	/**

--- a/spring-aot/src/main/java/org/springframework/boot/AotApplicationContextFactory.java
+++ b/spring-aot/src/main/java/org/springframework/boot/AotApplicationContextFactory.java
@@ -27,6 +27,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.ResourceLoader;
 
+import java.util.Arrays;
+
 /**
  * Prepare an application context for AOT processing.
  *
@@ -47,8 +49,9 @@ public final class AotApplicationContextFactory {
 	 * @param applicationClass an application class to be used as the root of the context
 	 * @return an application context whose environment has been loaded, but not refreshed
 	 */
-	public GenericApplicationContext createApplicationContext(Class<?> applicationClass) {
+	public GenericApplicationContext createApplicationContext(Class<?> applicationClass, Class<?>... primaryClasses) {
 		SpringApplication application = new SpringApplication(this.resourceLoader, applicationClass);
+		application.addPrimarySources(Arrays.asList(primaryClasses));
 		ConfigurableEnvironment environment = loadEnvironment(application);
 		GenericApplicationContext applicationContext = createApplicationContext(application);
 		applicationContext.setResourceLoader(this.resourceLoader);

--- a/spring-aot/src/test/java/org/springframework/aot/build/BootstrapCodeGeneratorTests.java
+++ b/spring-aot/src/test/java/org/springframework/aot/build/BootstrapCodeGeneratorTests.java
@@ -157,7 +157,7 @@ class BootstrapCodeGeneratorTests {
 	private ApplicationStructure getApplicationStructure(File tempDir) throws IOException {
 		return new ApplicationStructure(tempDir.toPath().resolve("sources"), tempDir.toPath().resolve("resources"),
 				Collections.emptySet(), Collections.emptyList(), "", "",
-				Collections.emptyList(), Collections.emptyList(), Thread.currentThread().getContextClassLoader());
+				Collections.emptyList(), Collections.emptyList(), Thread.currentThread().getContextClassLoader(), Collections.emptyList());
 	}
 
 	private BootstrapCodeGenerator createCodeGenerator(BootstrapContributor... contributors) {


### PR DESCRIPTION
***this is a draft pr***

When we start the spring application:
```
-               SpringApplication.run(new Class[] {
-                               Xxxx1Configuration.class,
-                               Xxxx2Configuration.class,
-                               Application.class
-               }, args);
```

spring native creates context using application class and ignores other classes, this will cause some registration of beans to be missing, maybe we can provide the manual configurable option to solve this problem.

Signed-off-by: wineway <wangyuweihx@gmail.com>