### PR TITLE
Adds back in cloud-stream-rabbit sample

### DIFF
--- a/samples/cloud-stream-kafka/pom.xml
+++ b/samples/cloud-stream-kafka/pom.xml
@@ -15,6 +15,21 @@
 	<name>cloud-stream-kafka</name>
 	<description>Demo project for SCSt Kafka</description>
 
+	<!-- TODO Remove the following dependencyManagement section once SCSt goes back to Boot snapshots and
+			fixes https://github.com/spring-cloud/spring-cloud-stream/issues/2465
+	-->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>3.0.0-M4</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/samples/cloud-stream-kafka/pom.xml
+++ b/samples/cloud-stream-kafka/pom.xml
@@ -32,16 +32,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -49,15 +41,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-function-context</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-function-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka</artifactId>
+			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/samples/cloud-stream-rabbit/build.sh
+++ b/samples/cloud-stream-rabbit/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker-compose up -d
+
+${PWD%/*samples/*}/scripts/install3rdPartyHints.sh && ${PWD%/*samples/*}/scripts/compileWithMaven.sh $* &&  ${PWD%/*samples/*}/scripts/test.sh $*
+
+docker-compose down

--- a/samples/cloud-stream-rabbit/docker-compose.yml
+++ b/samples/cloud-stream-rabbit/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - 5672:5672

--- a/samples/cloud-stream-rabbit/pom.xml
+++ b/samples/cloud-stream-rabbit/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.experimental</groupId>
+		<artifactId>spring-native-sample-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../maven-parent/pom.xml</relativePath>
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>cloud-stream-rabbit</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>cloud-stream-rabbit</name>
+	<description>Demo project for SCSt Rabbit</description>
+
+	<!-- TODO Remove the following dependencyManagement section once SCSt goes back to Boot snapshots and
+			fixes https://github.com/spring-cloud/spring-cloud-stream/issues/2465
+	-->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>3.0.0-M4</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-binder-rabbit</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/samples/cloud-stream-rabbit/src/main/java/com/example/demo/SpringCloudStreamRabbitApplication.java
+++ b/samples/cloud-stream-rabbit/src/main/java/com/example/demo/SpringCloudStreamRabbitApplication.java
@@ -1,0 +1,47 @@
+package com.example.demo;
+
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SpringCloudStreamRabbitApplication {
+
+	@Autowired
+	private StreamBridge streamBridge;
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringCloudStreamRabbitApplication.class, args);
+	}
+
+	@Bean
+	public Function<String, String> graalUppercaseFunction() {
+		return String::toUpperCase;
+	}
+
+	@Bean
+	public Consumer<String> graalLoggingConsumer() {
+		return s -> {
+			System.out.println("++++++Received:" + s);
+			// Verifying that StreamBridge API works in native applications.
+			streamBridge.send("sb-out", s);
+		};
+	}
+
+	@Bean
+	public Supplier<String> graalSupplier() {
+		return () -> {
+			String woodchuck = "How much wood could a woodchuck chuck if a woodchuck could chuck wood?";
+			final String[] splitWoodchuck = woodchuck.split(" ");
+			Random random = new Random();
+			return splitWoodchuck[random.nextInt(splitWoodchuck.length)];
+		};
+	}
+}

--- a/samples/cloud-stream-rabbit/src/main/resources/application.yml
+++ b/samples/cloud-stream-rabbit/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring.cloud:
+  function:
+    definition: graalSupplier;graalUppercaseFunction;graalLoggingConsumer
+  stream:
+    bindings:
+      graalSupplier-out-0:
+        destination: graalUppercaseFunction-in-0
+      graalLoggingConsumer-in-0:
+        destination: graalUppercaseFunction-out-0

--- a/samples/cloud-stream-rabbit/verify.sh
+++ b/samples/cloud-stream-rabbit/verify.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source ${PWD%/*samples/*}/scripts/wait.sh
+wait_log target/native/test-output.txt "Received:(HOW|MUCH|WOOD|COULD|A|WOODCHUCK|CHUCK|IF|COULD|WOOD?)"


### PR DESCRIPTION
This adds back in the SCSt Rabbit binder sample. 

* Current state of SCSt wrt to AOT/Native is that both Kafka and Rabbit binder samples work in AOT mode but not yet in Native mode. 
* Once this is merged these 2 samples can be moved into the smoke test repo. 

@mhalbritter do you mind merging this? 

Contributes toward #1532 