### PR TITLE
Add note to docs that mentions that the project is superseded

### DIFF
--- a/spring-native-docs/src/main/asciidoc/index.adoc
+++ b/spring-native-docs/src/main/asciidoc/index.adoc
@@ -2,6 +2,8 @@ include::attributes.adoc[]
 = Spring Native documentation
 Version {version} - Andy Clement; Sébastien Deleuze; Filip Hanik; Dave Syer; Esteban Ginez; Jay Bryant; Brian Clozel; Stéphane Nicoll; Josh Long
 
+IMPORTANT: Spring Native is now superseded by Spring Boot 3 official native support, see https://docs.spring.io/spring-boot/docs/current/reference/html/native-image.html[the related reference documentation] for more details.
+
 [[overview]]
 == Overview
 


### PR DESCRIPTION
This PR just copies the deprecation note from the project's README into the docs. 

Why? Because when I first looked into building native Spring Boot apps, I followed some links to https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#overview and thought that Spring Boot 3 was still using this project as a dependency. It took me some time to find out that this is not the case. I hope that having this note in the docs would help others to avoid wasting the time I wasted :).